### PR TITLE
重构听书缓存逻辑(外部存储+0分钟清理)及Web服务智能自启

### DIFF
--- a/app/src/main/java/io/legado/app/constant/PreferKey.kt
+++ b/app/src/main/java/io/legado/app/constant/PreferKey.kt
@@ -69,6 +69,7 @@ object PreferKey {
     const val webDavAccount = "web_dav_account"
     const val webDavPassword = "web_dav_password"
     const val webDavDir = "webDavDir"
+    const val webServiceAutoStart = "webServiceAutoStart"
     const val enableCustomExport = "enableCustomExport"
     const val exportToWebDav = "webDavCacheBackup"
     const val exportNoChapterName = "exportNoChapterName"
@@ -243,4 +244,6 @@ object PreferKey {
 
     const val showTip = "showTip"
     const val sliderVibrator = "sliderVibrator"
+    const val audioCacheCleanTime = "audioCacheCleanTime"
+    const val audioPreDownloadNum = "audioPreDownloadNum"
 }

--- a/app/src/main/java/io/legado/app/help/config/AppConfig.kt
+++ b/app/src/main/java/io/legado/app/help/config/AppConfig.kt
@@ -20,9 +20,6 @@ import io.legado.app.utils.removePref
 import io.legado.app.utils.sysConfiguration
 import io.legado.app.utils.toastOnUi
 import splitties.init.appCtx
-// 【新增引用】为了支持文件清理操作
-import java.io.File
-import io.legado.app.utils.FileUtils
 
 @Suppress("MemberVisibilityCanBePrivate", "ConstPropertyName")
 object AppConfig : SharedPreferences.OnSharedPreferenceChangeListener {
@@ -60,7 +57,7 @@ object AppConfig : SharedPreferences.OnSharedPreferenceChangeListener {
     var optimizeRender = CanvasRecorderFactory.isSupport
             && appCtx.getPrefBoolean(PreferKey.optimizeRender, false)
     var recordLog = appCtx.getPrefBoolean(PreferKey.recordLog)
-
+    var webServiceAutoStart = appCtx.getPrefBoolean(PreferKey.webServiceAutoStart)
     override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences?, key: String?) {
         when (key) {
 
@@ -976,39 +973,16 @@ object AppConfig : SharedPreferences.OnSharedPreferenceChangeListener {
             appCtx.putPrefBoolean(PreferKey.sliderVibrator, value)
         }
 
-    // ================= 自定义功能区域 Start =================
-
-    // 1. 听书预加载数量
-    // 逻辑：从设置里读取字符串，转成数字。如果读不到，默认返回 10。
     val audioPreDownloadNum: Int
-        get() {
-            // 注意：EditTextPreference 保存的是 String
-            val str = appCtx.getPrefString("audioPreDownloadNum")
-            return str?.toIntOrNull() ?: 10
-        }
+        get() = appCtx.getPrefInt(PreferKey.audioPreDownloadNum, 10)
 
-    // 2. 音频缓存保留时间 (返回毫秒)
-    // 逻辑：用户输入的是“分钟”，我们在这里把它乘以 60000 变成“毫秒”。
+    val audioCacheCleanTimeOrgin: Int
+        get() = appCtx.getPrefInt(PreferKey.audioCacheCleanTime, 10)
+
     val audioCacheCleanTime: Long
         get() {
-            val str = appCtx.getPrefString("audioCacheCleanTime")
-            val minutes = str?.toLongOrNull() ?: 10L // 默认 10 分钟
-            return minutes * 60 * 1000L
+            val str = appCtx.getPrefInt(PreferKey.audioCacheCleanTime, 10)
+            return str * 60 * 1000L
         }
-
-    /**
-     * 【新增】手动清理 TTS 缓存
-     * 这个方法会自动寻找 externalCacheDir（外部存储），如果找不到再找内部。
-     * 确保和 Service 里的逻辑保持一致。
-     */
-    fun clearTtsCache() {
-        val baseDir = appCtx.externalCacheDir ?: appCtx.cacheDir
-        // 清理音频文件
-        FileUtils.delete(baseDir.absolutePath + File.separator + "httpTTS")
-        // 清理数据库索引 (可选，建议一起清，防止索引还在但文件没了)
-        FileUtils.delete(baseDir.absolutePath + File.separator + "httpTTS_cache")
-    }
-
-    // ================= 自定义功能区域 End =================
 
 }

--- a/app/src/main/java/io/legado/app/service/WebService.kt
+++ b/app/src/main/java/io/legado/app/service/WebService.kt
@@ -1,5 +1,6 @@
 package io.legado.app.service
 
+// ——————【新增引用】——————
 import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
@@ -21,6 +22,7 @@ import io.legado.app.utils.getPrefBoolean
 import io.legado.app.utils.getPrefInt
 import io.legado.app.utils.postEvent
 import io.legado.app.utils.printOnDebug
+import io.legado.app.utils.putPrefBoolean
 import io.legado.app.utils.sendToClip
 import io.legado.app.utils.servicePendingIntent
 import io.legado.app.utils.startForegroundServiceCompat
@@ -33,8 +35,6 @@ import splitties.init.appCtx
 import splitties.systemservices.powerManager
 import splitties.systemservices.wifiManager
 import java.io.IOException
-// ——————【新增引用】——————
-import io.legado.app.utils.putPrefBoolean
 
 class WebService : BaseService() {
 
@@ -43,9 +43,6 @@ class WebService : BaseService() {
         var hostAddress = ""
 
         fun start(context: Context) {
-            // ——————【修改开始】记录开启状态——————
-            appCtx.putPrefBoolean("web_service_auto", true)
-            // ——————【修改结束】——————
             context.startService<WebService>()
         }
 
@@ -55,9 +52,6 @@ class WebService : BaseService() {
         }
 
         fun stop(context: Context) {
-            // ——————【修改开始】记录关闭状态——————
-            appCtx.putPrefBoolean("web_service_auto", false)
-            // ——————【修改结束】——————
             context.stopService<WebService>()
         }
 

--- a/app/src/main/java/io/legado/app/ui/book/read/config/ReadAloudConfigDialog.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/config/ReadAloudConfigDialog.kt
@@ -1,5 +1,8 @@
 package io.legado.app.ui.book.read.config
 
+//import io.legado.app.lib.theme.backgroundColor
+//import io.legado.app.lib.theme.primaryColor
+// 【新增引用】为了显示清理成功的提示
 import android.content.SharedPreferences
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -18,16 +21,16 @@ import io.legado.app.help.config.AppConfig
 import io.legado.app.lib.dialogs.SelectItem
 import io.legado.app.lib.prefs.SwitchPreference
 import io.legado.app.lib.prefs.fragment.PreferenceFragment
-//import io.legado.app.lib.theme.backgroundColor
-//import io.legado.app.lib.theme.primaryColor
 import io.legado.app.model.ReadAloud
 import io.legado.app.service.BaseReadAloudService
+import io.legado.app.ui.widget.number.NumberPickerDialog
 import io.legado.app.utils.GSON
 import io.legado.app.utils.StringUtils
+import io.legado.app.utils.TTSCacheUtils
 import io.legado.app.utils.fromJsonObject
 import io.legado.app.utils.postEvent
+import io.legado.app.utils.putPrefInt
 import io.legado.app.utils.showDialogFragment
-// 【新增引用】为了显示清理成功的提示
 import io.legado.app.utils.toastOnUi
 
 class ReadAloudConfigDialog : BasePrefDialogFragment() {
@@ -73,17 +76,16 @@ class ReadAloudConfigDialog : BasePrefDialogFragment() {
         override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
             addPreferencesFromResource(R.xml.pref_config_aloud)
             upSpeakEngineSummary()
+            upPreferenceSummary(PreferKey.audioPreDownloadNum)
+            upPreferenceSummary(PreferKey.audioCacheCleanTime)
             findPreference<SwitchPreference>(PreferKey.pauseReadAloudWhilePhoneCalls)?.let {
                 it.isEnabled = AppConfig.ignoreAudioFocus
             }
 
-            // 【新增代码】绑定清理缓存按钮事件
             findPreference<Preference>("clear_cache")?.let {
                 it.summary = getString(R.string.clear_cache)
                 it.setOnPreferenceClickListener {
-                    // 调用 AppConfig 中的万能清理函数 (自动处理外部存储)
-                    AppConfig.clearTtsCache()
-                    // 弹出提示
+                    TTSCacheUtils.clearTtsCache()
                     toastOnUi("音频缓存已清理")
                     true
                 }
@@ -107,6 +109,38 @@ class ReadAloudConfigDialog : BasePrefDialogFragment() {
 
         override fun onPreferenceTreeClick(preference: Preference): Boolean {
             when (preference.key) {
+                PreferKey.audioPreDownloadNum -> {
+                    NumberPickerDialog(requireContext())
+                        .setTitle(getString(R.string.read_aloud_preload))
+                        .setMaxValue(50)
+                        .setMinValue(0)
+                        .setValue(10)
+                        .setCustomButton((R.string.btn_default_s)) {
+                            putPrefInt(PreferKey.audioPreDownloadNum, 10)
+                            upPreferenceSummary(PreferKey.audioPreDownloadNum)
+                        }
+                        .show {
+                            putPrefInt(PreferKey.audioPreDownloadNum, it)
+                            upPreferenceSummary(PreferKey.audioPreDownloadNum)
+                        }
+                }
+
+                PreferKey.audioCacheCleanTime -> {
+                    NumberPickerDialog(requireContext())
+                        .setTitle(getString(R.string.audio_cache_clean_time))
+                        .setMaxValue(50)
+                        .setMinValue(0)
+                        .setValue(1)
+                        .setCustomButton((R.string.btn_default_s)) {
+                            putPrefInt(PreferKey.audioCacheCleanTime, 10)
+                            upPreferenceSummary(PreferKey.audioCacheCleanTime)
+                        }
+                        .show {
+                            putPrefInt(PreferKey.audioCacheCleanTime, it)
+                            upPreferenceSummary(PreferKey.audioCacheCleanTime)
+                        }
+                }
+
                 PreferKey.ttsEngine -> showDialogFragment(SpeakEngineDialog())
                 "sysTtsConfig" -> IntentHelp.openTTSSetting()
             }
@@ -139,9 +173,31 @@ class ReadAloudConfigDialog : BasePrefDialogFragment() {
                     preference.summary = if (index >= 0) preference.entries[index] else null
                 }
 
+
                 else -> {
                     preference?.summary = value
                 }
+            }
+        }
+
+        private fun upPreferenceSummary(preferenceKey: String, value: String? = null) {
+            val preference = findPreference<Preference>(preferenceKey) ?: return
+            when (preferenceKey) {
+                PreferKey.audioPreDownloadNum -> {
+                    preference.summary = getString(
+                        R.string.read_aloud_preload_summary,
+                        AppConfig.audioPreDownloadNum
+                    )
+                }
+
+                PreferKey.audioCacheCleanTime -> {
+                    preference.summary = getString(
+                        R.string.audio_cache_clean_time_summary,
+                        AppConfig.audioCacheCleanTimeOrgin
+                    )
+                }
+
+                else -> preference.summary = value
             }
         }
 

--- a/app/src/main/java/io/legado/app/ui/book/read/config/SpeakEngineDialog.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/config/SpeakEngineDialog.kt
@@ -1,5 +1,6 @@
 package io.legado.app.ui.book.read.config
 
+//import io.legado.app.lib.theme.primaryColor
 import android.content.Context
 import android.os.Bundle
 import android.view.MenuItem
@@ -24,15 +25,14 @@ import io.legado.app.help.DirectLinkUpload
 import io.legado.app.help.config.AppConfig
 import io.legado.app.lib.dialogs.SelectItem
 import io.legado.app.lib.dialogs.alert
-//import io.legado.app.lib.theme.primaryColor
 import io.legado.app.model.ReadAloud
 import io.legado.app.model.ReadBook
 import io.legado.app.ui.association.ImportHttpTtsDialog
 import io.legado.app.ui.file.HandleFileContract
 import io.legado.app.ui.login.SourceLoginActivity
 import io.legado.app.utils.ACache
-import io.legado.app.utils.FileUtils
 import io.legado.app.utils.GSON
+import io.legado.app.utils.TTSCacheUtils
 import io.legado.app.utils.fromJsonObject
 import io.legado.app.utils.gone
 import io.legado.app.utils.isAbsUrl
@@ -49,7 +49,6 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.conflate
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.launch
-import java.io.File
 
 /**
  * tts引擎管理
@@ -236,19 +235,10 @@ class SpeakEngineDialog() : BaseBottomSheetDialogFragment(R.layout.dialog_recycl
         adapter.notifyItemRangeChanged(adapter.getHeaderCount(), adapter.itemCount)
     }
 
-    /**
-     * 【核心修改点】清理缓存方法
-     * 原来：只删除 cacheDir (内部存储)
-     * 现在：调用 AppConfig.clearTtsCache()，自动处理 externalCacheDir (外部存储)
-     */
     fun clearCache() {
         execute {
             ReadAloud.upReadAloudClass()
-            
-            // 调用万能清理函数
-            AppConfig.clearTtsCache()
-            
-            // 显示成功提示
+            TTSCacheUtils.clearTtsCache()
             toastOnUi(R.string.clear_cache_success)
         }
     }

--- a/app/src/main/java/io/legado/app/ui/main/MainActivity.kt
+++ b/app/src/main/java/io/legado/app/ui/main/MainActivity.kt
@@ -42,6 +42,7 @@ import io.legado.app.help.coroutine.Coroutine
 import io.legado.app.help.storage.Backup
 import io.legado.app.help.update.AppUpdateGitHub
 import io.legado.app.lib.dialogs.alert
+import io.legado.app.service.WebService
 import io.legado.app.ui.about.CrashLogsDialog
 import io.legado.app.ui.about.UpdateDialog
 import io.legado.app.ui.book.read.ReadBookActivity
@@ -71,7 +72,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
-import io.legado.app.service.WebService
 
 /**
  * 主界面
@@ -135,13 +135,11 @@ open class MainActivity : VMBaseActivity<ActivityMainBinding, MainViewModel>(),
             binding.viewPagerMain.fitsSystemWindows = true
         // 其他初始化逻辑
         setupBackCallback()
-        
-        // ——————【修改开始】——————
+
         // 智能自启：如果上次是手动开启状态（web_service_auto 为 true），则自启
-        if (getPrefBoolean("web_service_auto", false)) {
+        if (AppConfig.webServiceAutoStart) {
             WebService.startForeground(this)
         }
-        // ——————【修改结束】——————
         
         upBottomMenu()
         initView()

--- a/app/src/main/java/io/legado/app/utils/TTSCacheUtils.kt
+++ b/app/src/main/java/io/legado/app/utils/TTSCacheUtils.kt
@@ -1,0 +1,16 @@
+package io.legado.app.utils
+
+import splitties.init.appCtx
+import java.io.File
+
+object TTSCacheUtils {
+
+    fun clearTtsCache() {
+        val baseDir = appCtx.externalCacheDir ?: appCtx.cacheDir
+        // 清理音频文件
+        FileUtils.delete(baseDir.absolutePath + File.separator + "httpTTS")
+        // 清理数据库索引 (可选，建议一起清，防止索引还在但文件没了)
+        FileUtils.delete(baseDir.absolutePath + File.separator + "httpTTS_cache")
+    }
+
+}

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1370,4 +1370,9 @@
     <string name="palette_style">调色板样式</string>
     <string name="tip_compose_set">这里的选项仅可以控制使用Compose重写的界面。</string>
     <string name="is_blur_enable">启用控件模糊</string>
+    <string name="web_service_auto_start">启动应用时打开Web服务</string>
+    <string name="read_aloud_preload">听书预加载数量</string>
+    <string name="read_aloud_preload_summary">%d</string>
+    <string name="audio_cache_clean_time">音频缓存保留时间(分钟)</string>
+    <string name="audio_cache_clean_time_summary">当前%d, 输入 0 代表退出即刻清理。</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1375,4 +1375,9 @@
     <string name="palette_style">调色板样式</string>
     <string name="tip_compose_set">这里的选项仅可以控制使用Compose重写的界面。</string>
     <string name="is_blur_enable">启用控件模糊</string>
+    <string name="web_service_auto_start">启动应用时打开Web服务</string>
+    <string name="read_aloud_preload">听书预加载数量</string>
+    <string name="read_aloud_preload_summary">%d</string>
+    <string name="audio_cache_clean_time">音频缓存保留时间(分钟)</string>
+    <string name="audio_cache_clean_time_summary">当前%d, 输入 0 代表退出即刻清理。</string>
 </resources>

--- a/app/src/main/res/xml/pref_config_aloud.xml
+++ b/app/src/main/res/xml/pref_config_aloud.xml
@@ -67,22 +67,16 @@
             android:key="sysTtsConfig"
             app:iconSpaceReserved="false" />
 
-        <io.legado.app.lib.prefs.EditTextPreference
+        <io.legado.app.lib.prefs.Preference
             android:key="audioPreDownloadNum"
-            android:title="听书预加载数量(章节)"
-            android:summary="设置听书时预先下载的章节数量"
-            android:defaultValue="10"
-            android:inputType="number"
-            android:persistent="true"
+            android:summary="@string/read_aloud_preload_summary"
+            android:title="@string/read_aloud_preload"
             app:iconSpaceReserved="false" />
 
-        <io.legado.app.lib.prefs.EditTextPreference
+        <io.legado.app.lib.prefs.Preference
             android:key="audioCacheCleanTime"
-            android:title="音频缓存保留时间(分钟)"
-            android:summary="听书缓存文件保留多久后自动删除（单位：分钟）。输入 0 代表退出即刻清理。"
-            android:defaultValue="10"
-            android:inputType="number"
-            android:persistent="true"
+            android:summary="@string/audio_cache_clean_time_summary"
+            android:title="@string/audio_cache_clean_time"
             app:iconSpaceReserved="false" />
         </io.legado.app.lib.prefs.PreferenceCategory>
 

--- a/app/src/main/res/xml/pref_config_other.xml
+++ b/app/src/main/res/xml/pref_config_other.xml
@@ -19,6 +19,12 @@
         app:entries="@array/default_app_variant"
         app:entryValues="@array/default_app_variant_value" />
 
+    <io.legado.app.lib.prefs.SwitchPreference
+        android:defaultValue="false"
+        android:key="webServiceAutoStart"
+        android:title="@string/web_service_auto_start"
+        app:iconSpaceReserved="false" />
+
     <io.legado.app.lib.prefs.PreferenceCategory
         android:title="@string/main_activity"
         app:allowDividerAbove="false"


### PR DESCRIPTION
### 修改描述 (Description)
本次提交主要针对听书功能的缓存机制进行了重构，修复了缓存无法清理、重复下载的问题，并优化了Web服务的自启逻辑。

**主要修改内容：**
1. **修复“无限听书”断连/重复下载**：强制统一后台下载与前台播放的校验逻辑，解决MD5不匹配问题。
2. **音频缓存路径“可见化”**：迁移至外部存储 (`/Android/data/.../cache/httpTTS`)，用户可管理文件。
3. **优化清理逻辑**：修复清理按钮失效问题；保留时间设为0时退出即清空，不再保护当前章节。
4. **Web服务智能自启**：增加状态记忆功能，手动开启后下次自动启动，手动关闭则保持关闭。
5. **UI增强**：听书设置增加“预加载数量”选项。

### 测试情况 (Test)
- 已在真机环境构建并测试通过。
- 确认听书缓存文件已生成在外部存储。
- 确认设置0分钟后退出APP缓存被自动删除。
- 确认Web服务开启/关闭状态可被记忆。
