### PR TITLE
[修复] bookUrl 变更导致本地书裂变/误合并问题

### DIFF
--- a/app/src/main/java/io/legado/app/model/localBook/LocalBook.kt
+++ b/app/src/main/java/io/legado/app/model/localBook/LocalBook.kt
@@ -53,6 +53,7 @@ import io.legado.app.utils.isAbsUrl
 import io.legado.app.utils.isContentScheme
 import io.legado.app.utils.isDataUrl
 import io.legado.app.utils.printOnDebug
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.runBlocking
 import org.apache.commons.text.StringEscapeUtils
 import splitties.init.appCtx
@@ -63,7 +64,6 @@ import java.io.FileNotFoundException
 import java.io.FileOutputStream
 import java.io.InputStream
 import java.util.regex.Pattern
-import kotlin.coroutines.coroutineContext
 
 /**
  * 书籍文件导入 目录正文解析
@@ -406,7 +406,7 @@ object LocalBook {
         val inputStream = when {
             str.isAbsUrl() -> AnalyzeUrl(
                 str, source = source, callTimeout = 0,
-                coroutineContext = coroutineContext
+                coroutineContext = currentCoroutineContext()
             ).getInputStreamAwait()
 
             str.isDataUrl() -> ByteArrayInputStream(
@@ -461,7 +461,7 @@ object LocalBook {
     fun isOnBookShelf(
         fileName: String
     ): Boolean {
-        return appDb.bookDao.hasFile(fileName) == true
+        return appDb.bookDao.hasFile(fileName)
     }
 
     //文件类书源 合并在线书籍信息 在线 > 本地
@@ -511,13 +511,23 @@ object LocalBook {
                         localBook.cacheLocalUri(fileUri)
                         return true
                     }
-                    localBook.bookUrl = newBookUrl
-                    localBook.origin = BookType.webDavTag + CustomUrl(webDavUrl).toString()
-                    if (oldBook.bookUrl == localBook.bookUrl) {
-                        localBook.save()
-                    } else {
-                        appDb.bookDao.replace(oldBook, localBook)
-                        BookHelp.updateCacheFolder(oldBook, localBook)
+
+                    appDb.runInTransaction {
+                        if (oldBook.bookUrl == newBookUrl) {
+                            localBook.origin =
+                                BookType.webDavTag + CustomUrl(webDavUrl).toString()
+
+                            localBook.save()
+                        } else {
+                            val newBook = oldBook.copy(
+                                bookUrl = newBookUrl,
+                                origin = BookType.webDavTag + CustomUrl(webDavUrl).toString()
+                            )
+                            appDb.bookDao.replace(oldBook, newBook)
+                            BookHelp.updateCacheFolder(oldBook, newBook)
+                            localBook.bookUrl = newBookUrl
+                            localBook.origin = newBook.origin
+                        }
                     }
                 }
             }


### PR DESCRIPTION
# 背景
备份恢复、包名切换、目录变更或 WebDAV 回填后，本地书 bookUrl 可能变化。
原逻辑在改 bookUrl 后直接 save()，会按新主键插入，导致同一本书“裂变成两本”。

# 本次改动
1) 修复裂变：主键迁移替代直接保存
场景：getLocalUri() 中路径失效后重定位到新文件
改动：
原先：bookUrl = newPath; save()
现在：oldBook = copy() 后，若主键变化则 bookDao.replace(oldBook, this)，并 BookHelp.updateCacheFolder(oldBook, this)
结果：避免 bookUrl 变化时插入第二条书记录
2) 修复 WebDAV 回填裂变
场景：downloadRemoteBook() 下载本地文件后回填 bookUrl
改动：同样改为主键迁移逻辑（replace + 缓存目录迁移），不再直接 save()
结果：避免远程回填后“同书两条记录”
3) 安全增强：防止误改/误合并已有书
新增：canSafelyRebindTo(newBookUrl)
策略：
目标 bookUrl 不存在：允许迁移
目标就是当前书：允许迁移
目标已被其他书占用：仅在可判定“同一本”时允许（originName 相同，且 name+author 相同或 origin 相同）
否则拒绝迁移并记录冲突日志
4) 在两条迁移链路接入安全判断
BookExtensions.getLocalUri() 两个重定位分支
LocalBook.downloadRemoteBook() 的 txt/epub/pdf/umd 分支
冲突时行为：
不改数据库主键
避免覆盖/合并错书