### PR TITLE
[优化] 引导增加选择保存书籍文件夹

### DIFF
--- a/app/src/main/java/io/legado/app/ui/welcome/BookFolderFragment.kt
+++ b/app/src/main/java/io/legado/app/ui/welcome/BookFolderFragment.kt
@@ -1,0 +1,37 @@
+package io.legado.app.ui.welcome
+
+import android.os.Bundle
+import android.view.View
+import io.legado.app.R
+import io.legado.app.base.BaseFragment
+import io.legado.app.databinding.FragmentBookFolderBinding
+import io.legado.app.help.config.AppConfig
+import io.legado.app.ui.file.HandleFileContract
+import io.legado.app.utils.viewbindingdelegate.viewBinding
+
+class BookFolderFragment : BaseFragment(R.layout.fragment_book_folder) {
+
+    private val binding by viewBinding(FragmentBookFolderBinding::bind)
+
+    private val selectBookFolder = registerForActivityResult(HandleFileContract()) { result ->
+        result.uri?.let { treeUri ->
+            AppConfig.defaultBookTreeUri = treeUri.toString()
+            updatePathText()
+        }
+    }
+
+    override fun onFragmentCreated(view: View, savedInstanceState: Bundle?) {
+        binding.btnSelectFolder.setOnClickListener {
+            selectBookFolder.launch {
+                title = getString(R.string.select_book_folder)
+                mode = HandleFileContract.DIR_SYS
+            }
+        }
+        updatePathText()
+    }
+
+    private fun updatePathText() {
+        binding.tvFolderPath.text =
+            AppConfig.defaultBookTreeUri ?: getString(R.string.welcome_book_folder_not_selected)
+    }
+}

--- a/app/src/main/java/io/legado/app/ui/welcome/WelcomeActivity.kt
+++ b/app/src/main/java/io/legado/app/ui/welcome/WelcomeActivity.kt
@@ -19,6 +19,7 @@ class WelcomeActivity : BaseActivity<ActivityWelcomeBinding>() {
     private val pages = listOf(
         PrivacyFragment(),
         WebDavFragment(),
+        BookFolderFragment(),
         ThemeFragment()
     )
 
@@ -54,11 +55,13 @@ class WelcomeActivity : BaseActivity<ActivityWelcomeBinding>() {
                 binding.tvTitle.text = when (position) {
                     0 -> "欢迎！" // PrivacyFragment
                     1 -> "备份与恢复"
+                    2 -> "书籍文件夹"
                     else -> "主题样式"
                 }
                 binding.tvSummary.text = when (position) {
                     0 -> "请先阅读应用的服务条款与用户协议。"
                     1 -> "此处可设置云同步与恢复应用备份。"
+                    2 -> "请选择保存本地书籍的文件夹。"
                     else -> "在这里设置您喜爱的样式。"
                 }
                 updateProgress(position)

--- a/app/src/main/res/layout/fragment_book_folder.xml
+++ b/app/src/main/res/layout/fragment_book_folder.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:paddingHorizontal="16dp">
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/welcome_book_folder_tip"
+        android:textColor="?attr/colorOnSurfaceVariant"
+        android:textSize="14sp" />
+
+    <com.google.android.material.card.MaterialCardView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
+        app:cardBackgroundColor="?attr/colorSurfaceContainerLow"
+        app:cardCornerRadius="16dp"
+        app:cardElevation="0dp"
+        app:strokeColor="?attr/colorOutlineVariant"
+        app:strokeWidth="1dp">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:padding="14dp">
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/select_book_folder"
+                android:textColor="?attr/colorOnSurface"
+                android:textStyle="bold" />
+
+            <TextView
+                android:id="@+id/tvFolderPath"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:maxLines="3"
+                android:textColor="?attr/colorOnSurfaceVariant"
+                android:textSize="13sp" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btnSelectFolder"
+                style="@style/Widget.Material3Expressive.Button.OutlinedButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:text="@string/select_folder" />
+
+        </LinearLayout>
+
+    </com.google.android.material.card.MaterialCardView>
+
+</LinearLayout>
+

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1248,6 +1248,8 @@
     <string name="clear_all">清除所有</string>
     <string name="welcome_title">欢迎！</string>
     <string name="first_read">请先阅读应用的服务条款与用户协议。</string>
+    <string name="welcome_book_folder_tip">设置本地书籍保存目录，后续也可在设置中修改。</string>
+    <string name="welcome_book_folder_not_selected">未选择文件夹</string>
     <string name="config_btn">配置底部按钮</string>
     <string name="compact_grid">紧凑网格</string>
     <string name="cover_grid">封面网格</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -1214,4 +1214,6 @@
     <string name="sure_cache_book">是否确认开始缓存？</string>
     <string name="auto_check_new_backup_t">自动检查新备份</string>
     <string name="auto_check_new_backup_s">打开软件时检查是否有新备份，有新备份时提示是否更新</string>
+    <string name="welcome_book_folder_tip">设置本地书籍保存目录，后续也可在设置中修改。</string>
+    <string name="welcome_book_folder_not_selected">未选择文件夹</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1216,4 +1216,6 @@
     <string name="sure_cache_book">是否确认开始缓存？</string>
     <string name="auto_check_new_backup_t">自动检查新备份</string>
     <string name="auto_check_new_backup_s">打开软件时检查是否有新备份，有新备份时提示是否更新</string>
+    <string name="welcome_book_folder_tip">设置本地书籍保存目录，后续也可在设置中修改。</string>
+    <string name="welcome_book_folder_not_selected">未选择文件夹</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1251,6 +1251,8 @@
     <string name="clear_all">Clear All</string>
     <string name="welcome_title">Welcome!</string>
     <string name="first_read">Please read the Terms of Service and User Agreement first.</string>
+    <string name="welcome_book_folder_tip">Set where local books are stored. You can change it later in Settings.</string>
+    <string name="welcome_book_folder_not_selected">No folder selected</string>
     <string name="config_btn">Configure Bottom Buttons</string>
     <string name="compact_grid">Compact Grid</string>
     <string name="cover_grid">Cover Grid</string>


### PR DESCRIPTION

新增步骤页 BookFolderFragment，可直接选择并保存 AppConfig.defaultBookTreeUri

<img width="355" height="809" alt="image" src="https://github.com/user-attachments/assets/4f3c50fa-2eb4-4b36-9b9e-fc8b64f8f09e" />
