### PR TITLE
底部导航栏在跨页面滑动时的图标闪现

### DIFF
--- a/app/src/main/java/io/legado/app/ui/main/MainScreen.kt
+++ b/app/src/main/java/io/legado/app/ui/main/MainScreen.kt
@@ -137,7 +137,7 @@ fun MainScreen(
                 }
             ) {
                 destinations.forEachIndexed { index, destination ->
-                    val selected = pagerState.currentPage == index
+                    val selected = pagerState.targetPage == index
                     WideNavigationRailItem(
                         railExpanded = navState.targetValue == WideNavigationRailValue.Expanded,
                         selected = selected,


### PR DESCRIPTION
问题描述：
在跨页切换（如从 ‘书架’ 跨到‘订阅’）时，由于底部导航栏绑定的是 currentPage，图标状态会在经过中间页（发现）时产生短暂的“闪现”激活效果，且目标页图标反馈有延迟。

修复方案：
将底部导航栏的状态绑定改为 targetPage。同时消除了跨页面跳转的导航栏闪现，同时不影响相邻页面的滑动切换的导航栏同步

不确定闪现效果是否是刻意为之，只是我个人感觉有点突兀，做出的修改