### PR TITLE
修复 #1142

### DIFF
--- a/app/src/main/java/io/legado/app/ui/main/bookshelf/BookshelfScreen.kt
+++ b/app/src/main/java/io/legado/app/ui/main/bookshelf/BookshelfScreen.kt
@@ -210,60 +210,6 @@ fun BookshelfScreen(
         }
     )
 
-    if (uiState.groups.isEmpty()) {
-        val scrollBehavior = GlassTopAppBarDefaults.defaultScrollBehavior()
-        val onSearchClick = {
-            if (BookshelfConfig.bookshelfSearchActionDirectToSearchState.value) {
-                onNavigateToSearch(uiState.searchKey.trim())
-            } else {
-                viewModel.setSearchMode(!uiState.isSearch)
-            }
-        }
-        AppScaffold(
-            modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
-            contentWindowInsets = WindowInsets(0),
-            snackbarHost = {
-                SnackbarHost(
-                    hostState = snackbarHostState,
-                    modifier = Modifier
-                        .padding(
-
-                            bottom = 72.dp + WindowInsets.navigationBars
-                                .asPaddingValues()
-                                .calculateBottomPadding()
-                        )
-                )
-            },
-            topBar = {
-                BookshelfTopBar(
-                    uiState = uiState,
-                    scrollBehavior = scrollBehavior,
-                    onSearchClick = onSearchClick,
-                    onSearchQueryChange = { viewModel.setSearchKey(it) },
-                    onSearchSubmit = { rawQuery ->
-                        rawQuery.trim()
-                            .takeIf { it.isNotEmpty() }
-                            ?.let(onNavigateToSearch)
-                    },
-                    onClearSearch = { viewModel.setSearchKey("") }
-                )
-            }
-        ) { paddingValues ->
-            if (!uiState.isInitialLoading) {
-                EmptyMessage(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .padding(
-                            top = paddingValues.calculateTopPadding(),
-                            bottom = 120.dp
-                        ),
-                    messageResId = R.string.bookshelf_empty
-                )
-            }
-        }
-        return
-    }
-
     val activeOverlay = uiState.activeOverlay
     val showGroupMenu = activeOverlay == BookshelfOverlay.GroupMenu
     val isEditMode = uiState.isEditMode
@@ -280,7 +226,7 @@ fun BookshelfScreen(
     }
 
     val pagerState = rememberPagerState(
-        initialPage = uiState.selectedGroupIndex,
+        initialPage = uiState.selectedGroupIndex.coerceAtLeast(0),
         pageCount = { uiState.groups.size }
     )
     val latestGroups by rememberUpdatedState(uiState.groups)
@@ -765,7 +711,19 @@ fun BookshelfScreen(
                     }
                 }
             ) { isRoot ->
-                if (bookGroupStyle == 2 && isRoot && !isUsingStandaloneSearchGroup) {
+                if (uiState.groups.isEmpty() && !uiState.isSearch) {
+                    if (!uiState.isInitialLoading) {
+                        EmptyMessage(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .padding(
+                                    top = paddingValues.calculateTopPadding(),
+                                    bottom = 120.dp
+                                ),
+                            messageResId = R.string.bookshelf_empty
+                        )
+                    }
+                } else if (bookGroupStyle == 2 && isRoot && !isUsingStandaloneSearchGroup) {
                     val folderColumns =
                         if (bookshelfFolderLayoutMode == 0) bookshelfFolderLayoutList else bookshelfFolderLayoutGrid
                     val isGridMode = bookshelfFolderLayoutMode != 0


### PR DESCRIPTION
<img width="865" height="1260" alt="PixPin_2026-05-22_23-38-16" src="https://github.com/user-attachments/assets/b45f3333-62d3-49cd-86cd-eaa26b677254" />

修复了代码在 uiState.groups.isEmpty() 的分支中，漏传了 actions 参数导致 MoreVert 按钮消失的bug。

现在隐藏掉所有分组不会导致 MoreVert 消失了。

Fixes #1142