### PR TITLE
修复封面保存在cache路径里导致意外被清理的bug

### DIFF
--- a/app/src/main/java/io/legado/app/ui/book/info/edit/BookInfoEditViewModel.kt
+++ b/app/src/main/java/io/legado/app/ui/book/info/edit/BookInfoEditViewModel.kt
@@ -18,11 +18,11 @@ import io.legado.app.help.book.removeType
 import io.legado.app.model.ReadBook
 import io.legado.app.utils.FileUtils
 import io.legado.app.utils.MD5Utils
+import io.legado.app.utils.externalFiles
 import io.legado.app.utils.inputStream
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import java.io.File
 import java.io.FileOutputStream
 
 enum class BookInfoEditType {
@@ -157,20 +157,15 @@ class BookInfoEditViewModel(application: Application) : BaseViewModel(applicatio
     fun coverChangeTo(context: Context, uri: Uri) {
         execute {
             runCatching {
-                context.externalCacheDir?.let { externalCacheDir ->
-                    val file = File(externalCacheDir, "covers")
-                    val suffix = context.contentResolver.getType(uri)?.substringAfterLast("/") ?: "jpg"
-                    val fileName = uri.inputStream(context).getOrThrow().use { MD5Utils.md5Encode(it) } + ".$suffix"
-                    val coverFile = FileUtils.createFileIfNotExist(file, fileName)
-                    context.contentResolver.openInputStream(uri)?.use { inputStream ->
-                        FileOutputStream(coverFile).use { outputStream ->
-                            inputStream.copyTo(outputStream)
-                        }
+                val suffix = context.contentResolver.getType(uri)?.substringAfterLast("/") ?: "jpg"
+                val fileName = uri.inputStream(context).getOrThrow().use { MD5Utils.md5Encode(it) } + ".$suffix"
+                val coverFile = FileUtils.createFileIfNotExist(context.externalFiles, "covers", fileName)
+                context.contentResolver.openInputStream(uri)?.use { inputStream ->
+                    FileOutputStream(coverFile).use { outputStream ->
+                        inputStream.copyTo(outputStream)
                     }
-                    _uiState.value = _uiState.value.copy(coverUrl = coverFile.absolutePath)
-                } ?: run {
-                    AppLog.put("External cache directory is null", Throwable("Null directory"), true)
                 }
+                _uiState.value = _uiState.value.copy(coverUrl = coverFile.absolutePath)
             }.onFailure {
                 AppLog.put("书籍封面保存失败\n$it", it, true)
             }

--- a/app/src/main/java/io/legado/app/ui/book/info/edit/BookInfoEditViewModel.kt
+++ b/app/src/main/java/io/legado/app/ui/book/info/edit/BookInfoEditViewModel.kt
@@ -23,6 +23,7 @@ import io.legado.app.utils.inputStream
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import java.io.File
 import java.io.FileOutputStream
 
 enum class BookInfoEditType {
@@ -158,12 +159,20 @@ class BookInfoEditViewModel(application: Application) : BaseViewModel(applicatio
         execute {
             runCatching {
                 val suffix = context.contentResolver.getType(uri)?.substringAfterLast("/") ?: "jpg"
-                val fileName = uri.inputStream(context).getOrThrow().use { MD5Utils.md5Encode(it) } + ".$suffix"
-                val coverFile = FileUtils.createFileIfNotExist(context.externalFiles, "covers", fileName)
-                context.contentResolver.openInputStream(uri)?.use { inputStream ->
-                    FileOutputStream(coverFile).use { outputStream ->
+                val coversDir = FileUtils.createFolderIfNotExist(context.externalFiles, "covers")
+                val tempFile = File(coversDir, "${System.currentTimeMillis()}.tmp")
+                uri.inputStream(context).getOrThrow().use { inputStream ->
+                    FileOutputStream(tempFile).use { outputStream ->
                         inputStream.copyTo(outputStream)
                     }
+                }
+                val md5 = tempFile.inputStream().use { MD5Utils.md5Encode(it) }
+                val coverFile = File(coversDir, "$md5.$suffix")
+                if (coverFile.exists()) {
+                    tempFile.delete()
+                } else if (!tempFile.renameTo(coverFile)) {
+                    tempFile.copyTo(coverFile, overwrite = true)
+                    tempFile.delete()
                 }
                 _uiState.value = _uiState.value.copy(coverUrl = coverFile.absolutePath)
             }.onFailure {


### PR DESCRIPTION

<img width="749" height="1293" alt="PixPin_2026-05-24_14-39-12" src="https://github.com/user-attachments/assets/8a67ef12-0197-43e8-9d24-70c38d34b30e" />

现在上传自定义封面不会再上传到cache里了，如果之前上传过，还需要再次上传一次来确保生效。

Fixed #1165 