### PR TITLE
修复 (#1167)

### DIFF
--- a/app/src/main/java/io/legado/app/ui/book/read/config/ReadStyleDialog.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/config/ReadStyleDialog.kt
@@ -111,7 +111,6 @@ class ReadStyleDialog : BaseBottomSheetDialogFragment(R.layout.dialog_read_book_
 
         tvPadding.setOnClickListener {
             callBack?.showInfoConfig()
-            dismissAllowingStateLoss()
         }
         tvTip.setOnClickListener {
             TipConfigDialog().show(childFragmentManager, "tipConfigDialog")


### PR DESCRIPTION
移除 tvPadding 点击事件中的 dismissAllowingStateLoss()

<img width="1228" height="1238" alt="PixPin_2026-05-27_18-00-06" src="https://github.com/user-attachments/assets/0e7a6b0c-8d61-4da3-90e6-8e77d1dad387" />
 
Fixed #1167 