### PR TITLE
修复边距调整的遮挡问题

### DIFF
--- a/app/src/main/java/io/legado/app/ui/book/read/config/InfoConfigDialog.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/config/InfoConfigDialog.kt
@@ -1,5 +1,6 @@
 package io.legado.app.ui.book.read.config
 
+import android.content.DialogInterface
 import android.os.Bundle
 import android.view.View
 import com.jaredrummler.android.colorpicker.ColorPickerDialog
@@ -21,6 +22,7 @@ class InfoConfigDialog : BaseBottomSheetDialogFragment(R.layout.dialog_read_info
 
     private val binding by viewBinding(DialogReadInfoBinding::bind)
     private val callBack get() = activity as? ReadBookActivity
+    private var dismissBySelf = false;
 
     override val curFontPath: String
         get() = ReadBookConfig.headerFont
@@ -47,6 +49,11 @@ class InfoConfigDialog : BaseBottomSheetDialogFragment(R.layout.dialog_read_info
         }
     }
 
+    override fun onDismiss(dialog: DialogInterface) {
+        super.onDismiss(dialog)
+        if(dismissBySelf) return;
+        callBack?.showReadStyle()
+    }
     private fun initView() {
         ReadTipConfig.run {
             tipNames.let { tipNames ->
@@ -66,6 +73,7 @@ class InfoConfigDialog : BaseBottomSheetDialogFragment(R.layout.dialog_read_info
         }
         binding.btnPaddingSetting.setOnClickListener {
             callBack?.showPaddingConfig()
+            dismissBySelf = true;
             dismissAllowingStateLoss()
         }
         upTvHeaderColor()

--- a/app/src/main/java/io/legado/app/ui/book/read/config/InfoConfigDialog.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/config/InfoConfigDialog.kt
@@ -22,7 +22,7 @@ class InfoConfigDialog : BaseBottomSheetDialogFragment(R.layout.dialog_read_info
 
     private val binding by viewBinding(DialogReadInfoBinding::bind)
     private val callBack get() = activity as? ReadBookActivity
-    private var dismissBySelf = false;
+    private var dismissBySelf = false
 
     override val curFontPath: String
         get() = ReadBookConfig.headerFont
@@ -51,8 +51,11 @@ class InfoConfigDialog : BaseBottomSheetDialogFragment(R.layout.dialog_read_info
 
     override fun onDismiss(dialog: DialogInterface) {
         super.onDismiss(dialog)
-        if(dismissBySelf) return;
-        callBack?.showReadStyle()
+        if(dismissBySelf) return
+        val activity = activity ?: return
+        if (!activity.isFinishing) {
+            callBack?.showReadStyle()
+        }
     }
     private fun initView() {
         ReadTipConfig.run {
@@ -73,7 +76,7 @@ class InfoConfigDialog : BaseBottomSheetDialogFragment(R.layout.dialog_read_info
         }
         binding.btnPaddingSetting.setOnClickListener {
             callBack?.showPaddingConfig()
-            dismissBySelf = true;
+            dismissBySelf = true
             dismissAllowingStateLoss()
         }
         upTvHeaderColor()

--- a/app/src/main/java/io/legado/app/ui/book/read/config/PaddingConfigDialog.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/config/PaddingConfigDialog.kt
@@ -8,6 +8,7 @@ import io.legado.app.base.BaseDialogFragment
 import io.legado.app.constant.EventBus
 import io.legado.app.databinding.DialogReadPaddingBinding
 import io.legado.app.help.config.ReadBookConfig
+import io.legado.app.ui.book.read.ReadBookActivity
 import io.legado.app.utils.postEvent
 import io.legado.app.utils.setLayout
 import io.legado.app.utils.viewbindingdelegate.viewBinding
@@ -15,7 +16,6 @@ import io.legado.app.utils.viewbindingdelegate.viewBinding
 class PaddingConfigDialog : BaseDialogFragment(R.layout.dialog_read_padding) {
 
     private val binding by viewBinding(DialogReadPaddingBinding::bind)
-
     override fun onFragmentCreated(view: View, savedInstanceState: Bundle?) {
         initData()
         initView()
@@ -24,6 +24,7 @@ class PaddingConfigDialog : BaseDialogFragment(R.layout.dialog_read_padding) {
     override fun onDismiss(dialog: DialogInterface) {
         super.onDismiss(dialog)
         ReadBookConfig.save()
+        (activity as? ReadBookActivity)?.showInfoConfig()
     }
 
     override fun onStart() {

--- a/app/src/main/java/io/legado/app/ui/book/read/config/PaddingConfigDialog.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/config/PaddingConfigDialog.kt
@@ -24,7 +24,10 @@ class PaddingConfigDialog : BaseDialogFragment(R.layout.dialog_read_padding) {
     override fun onDismiss(dialog: DialogInterface) {
         super.onDismiss(dialog)
         ReadBookConfig.save()
-        (activity as? ReadBookActivity)?.showInfoConfig()
+        val activity = activity ?: return
+        if (!activity.isFinishing) {
+            (activity as? ReadBookActivity)?.showInfoConfig()
+        }
     }
 
     override fun onStart() {

--- a/app/src/main/java/io/legado/app/ui/book/read/config/ReadStyleDialog.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/config/ReadStyleDialog.kt
@@ -111,6 +111,7 @@ class ReadStyleDialog : BaseBottomSheetDialogFragment(R.layout.dialog_read_book_
 
         tvPadding.setOnClickListener {
             callBack?.showInfoConfig()
+            dismissAllowingStateLoss()
         }
         tvTip.setOnClickListener {
             TipConfigDialog().show(childFragmentManager, "tipConfigDialog")


### PR DESCRIPTION
<img width="832" height="1206" alt="PixPin_2026-05-30_23-51-37" src="https://github.com/user-attachments/assets/2827ff4e-ff82-4a4a-9654-9947bbc2ce4c" />

现在不会遮挡，也能够正常返回上级菜单。

Fixed #1235 