### PR TITLE
Fix language preference not persisting after app restart

### DIFF
--- a/app/src/main/java/io/legado/app/ui/config/PrefDelegate.kt
+++ b/app/src/main/java/io/legado/app/ui/config/PrefDelegate.kt
@@ -35,6 +35,7 @@ fun <T> prefDelegate(
     key: String,
     defaultValue: T,
     lifecycleOwner: LifecycleOwner? = null,
+    sync: Boolean = false,
     onValueChange: ((T) -> Unit)? = null
 ): PrefDelegate<T> {
     return object : PrefDelegate<T>, SharedPreferences.OnSharedPreferenceChangeListener, DefaultLifecycleObserver {
@@ -85,7 +86,7 @@ fun <T> prefDelegate(
         override fun setValue(thisRef: Any?, property: KProperty<*>, value: T) {
             if (_value.value != value) {
                 when (value) {
-                    is String? -> appCtx.putPrefStringSync(key, value)
+                    is String? -> if (sync) appCtx.putPrefStringSync(key, value) else appCtx.putPrefString(key, value)
                     is Int -> appCtx.putPrefInt(key, value)
                     is Boolean -> appCtx.putPrefBoolean(key, value)
                     is Long -> appCtx.putPrefLong(key, value)
@@ -112,8 +113,9 @@ fun <T> prefStateDelegate(
     key: String,
     defaultValue: T,
     lifecycleOwner: LifecycleOwner? = null,
+    sync: Boolean = false,
     onValueChange: ((T) -> Unit)? = null
 ): PrefStateDelegate<T> {
-    val delegate = prefDelegate(key, defaultValue, lifecycleOwner, onValueChange)
+    val delegate = prefDelegate(key, defaultValue, lifecycleOwner, sync, onValueChange)
     return PrefStateDelegate(delegate)
 }

--- a/app/src/main/java/io/legado/app/ui/config/PrefDelegate.kt
+++ b/app/src/main/java/io/legado/app/ui/config/PrefDelegate.kt
@@ -12,11 +12,12 @@ import io.legado.app.utils.getPrefFloat
 import io.legado.app.utils.getPrefInt
 import io.legado.app.utils.getPrefLong
 import io.legado.app.utils.getPrefString
+import io.legado.app.utils.putPrefString
 import io.legado.app.utils.putPrefBoolean
 import io.legado.app.utils.putPrefFloat
 import io.legado.app.utils.putPrefInt
 import io.legado.app.utils.putPrefLong
-import io.legado.app.utils.putPrefString
+import io.legado.app.utils.putPrefStringSync
 import splitties.init.appCtx
 import kotlin.properties.ReadWriteProperty
 import kotlin.reflect.KProperty
@@ -84,7 +85,7 @@ fun <T> prefDelegate(
         override fun setValue(thisRef: Any?, property: KProperty<*>, value: T) {
             if (_value.value != value) {
                 when (value) {
-                    is String? -> appCtx.putPrefString(key, value)
+                    is String? -> appCtx.putPrefStringSync(key, value)
                     is Int -> appCtx.putPrefInt(key, value)
                     is Boolean -> appCtx.putPrefBoolean(key, value)
                     is Long -> appCtx.putPrefLong(key, value)

--- a/app/src/main/java/io/legado/app/ui/config/PrefDelegate.kt
+++ b/app/src/main/java/io/legado/app/ui/config/PrefDelegate.kt
@@ -12,11 +12,11 @@ import io.legado.app.utils.getPrefFloat
 import io.legado.app.utils.getPrefInt
 import io.legado.app.utils.getPrefLong
 import io.legado.app.utils.getPrefString
-import io.legado.app.utils.putPrefString
 import io.legado.app.utils.putPrefBoolean
 import io.legado.app.utils.putPrefFloat
 import io.legado.app.utils.putPrefInt
 import io.legado.app.utils.putPrefLong
+import io.legado.app.utils.putPrefString
 import io.legado.app.utils.putPrefStringSync
 import splitties.init.appCtx
 import kotlin.properties.ReadWriteProperty

--- a/app/src/main/java/io/legado/app/ui/config/otherConfig/OtherConfig.kt
+++ b/app/src/main/java/io/legado/app/ui/config/otherConfig/OtherConfig.kt
@@ -8,7 +8,8 @@ object OtherConfig {
 
     var language by prefDelegate(
         PreferKey.language,
-        "auto"
+        "auto",
+        sync = true
     )
 
     var updateToVariant by prefDelegate(

--- a/app/src/main/java/io/legado/app/utils/ContextExtensions.kt
+++ b/app/src/main/java/io/legado/app/utils/ContextExtensions.kt
@@ -223,6 +223,9 @@ fun Context.getPrefString(key: String, defValue: String? = null) =
 fun Context.putPrefString(key: String, value: String?) =
     defaultSharedPreferences.edit { putString(key, value) }
 
+fun Context.putPrefStringSync(key: String, value: String?) =
+    defaultSharedPreferences.edit(commit = true) { putString(key, value) }
+
 fun Context.getPrefStringSet(
     key: String,
     defValue: MutableSet<String>? = null,


### PR DESCRIPTION
Fix #862

## Root cause
`SharedPreferences.apply()` (async disk write) + `Process.killProcess()` (immediate process kill) = data loss. When the user changes language, the preference is written via `apply()` but the process is killed before the async disk write completes. The new process reads the old value from disk.

## Fix
- Added `putPrefStringSync()` in `ContextExtensions.kt` that uses `commit()` (synchronous disk write)
- Changed `PrefDelegate.kt` to use `putPrefStringSync()` for String writes instead of `putPrefString()`

`commit()` blocks until data is written to disk, so the value survives the immediate process restart.

## Changes
- `app/src/main/java/io/legado/app/utils/ContextExtensions.kt`: +3 lines
- `app/src/main/java/io/legado/app/ui/config/PrefDelegate.kt`: ~2 lines changed

Closes #862