### PR TITLE
fix:修复菜单打开及切换配置时状态栏颜色未同步更新的问题

### DIFF
--- a/app/src/main/java/io/legado/app/help/config/ReadBookConfig.kt
+++ b/app/src/main/java/io/legado/app/help/config/ReadBookConfig.kt
@@ -1,6 +1,7 @@
 package io.legado.app.help.config
 
 import android.content.Context
+import android.graphics.Color
 import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.ColorDrawable
 import android.graphics.drawable.Drawable
@@ -340,7 +341,29 @@ object ReadBookConfig {
         }
 
     val resolvedMenuBgColor: Int
-        get() = if (ReadStyleResolver.isNightTheme()) readMenuBgColorNight else readMenuBgColor
+        get() {
+            val isNight = ReadStyleResolver.isNightTheme()
+            return when (AppConfig.readBarStyle) {
+                1 -> { // 跟随阅读背景
+                    val background = ReadStyleResolver.currentBackground(durConfig)
+                    if (background.type == 0) {
+                        try {
+                            background.value.toColorInt()
+                        } catch (_: Exception) {
+                            if (isNight) Color.BLACK else Color.WHITE
+                        }
+                    } else {
+                        bgMeanColor.takeIf { it != 0 } ?: (if (isNight) Color.BLACK else Color.WHITE)
+                    }
+                }
+                2 -> { // 自定义
+                    if (isNight) readMenuBgColorNight else readMenuBgColor
+                }
+                else -> {
+                    if (isNight) Color.BLACK else Color.WHITE
+                }
+            }
+        }
 
     val resolvedMenuAccentColor: Int
         get() = if (ReadStyleResolver.isNightTheme()) readMenuAccentColorNight else readMenuAccentColor

--- a/app/src/main/java/io/legado/app/ui/book/read/ReadBookContract.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/ReadBookContract.kt
@@ -737,7 +737,7 @@ sealed interface ConfigUpdate {
 
     // --- Layout / style ---
     data class StyleSelect(val index: Int) : ConfigUpdate {
-        override val actions = setOf(ConfigUpdateAction.UpdateBackground, ConfigUpdateAction.UpdateStyle, ConfigUpdateAction.ReloadContent)
+        override val actions = setOf(ConfigUpdateAction.UpdateBackground, ConfigUpdateAction.UpdateStyle, ConfigUpdateAction.ReloadContent, ConfigUpdateAction.UpdateSystemUi)
     }
     data class ShareLayout(val value: Boolean) : ConfigUpdate {
         override val actions = setOf(ConfigUpdateAction.UpdateBackground, ConfigUpdateAction.UpdateStyle, ConfigUpdateAction.ReloadContent)
@@ -748,7 +748,7 @@ sealed interface ConfigUpdate {
 
     // --- Menu colors ---
     data class MenuBgColor(val color: Int) : ConfigUpdate {
-        override val actions = setOf(ConfigUpdateAction.UpdateBackground, ConfigUpdateAction.UpdateStyle, ConfigUpdateAction.ReloadContent)
+        override val actions = setOf(ConfigUpdateAction.UpdateBackground, ConfigUpdateAction.UpdateStyle, ConfigUpdateAction.ReloadContent, ConfigUpdateAction.UpdateSystemUi)
     }
     data class MenuAccentColor(val color: Int) : ConfigUpdate {
         override val actions = setOf(ConfigUpdateAction.UpdateBackground, ConfigUpdateAction.UpdateStyle, ConfigUpdateAction.ReloadContent)
@@ -757,7 +757,7 @@ sealed interface ConfigUpdate {
         override val actions = setOf(ConfigUpdateAction.UpdateBackground, ConfigUpdateAction.UpdateStyle, ConfigUpdateAction.ReloadContent)
     }
     data class MenuBgColorNight(val color: Int) : ConfigUpdate {
-        override val actions = setOf(ConfigUpdateAction.UpdateBackground, ConfigUpdateAction.UpdateStyle, ConfigUpdateAction.ReloadContent)
+        override val actions = setOf(ConfigUpdateAction.UpdateBackground, ConfigUpdateAction.UpdateStyle, ConfigUpdateAction.ReloadContent, ConfigUpdateAction.UpdateSystemUi)
     }
     data class MenuAccentColorNight(val color: Int) : ConfigUpdate {
         override val actions = setOf(ConfigUpdateAction.UpdateBackground, ConfigUpdateAction.UpdateStyle, ConfigUpdateAction.ReloadContent)
@@ -766,10 +766,10 @@ sealed interface ConfigUpdate {
         override val actions = setOf(ConfigUpdateAction.UpdateBackground, ConfigUpdateAction.UpdateStyle, ConfigUpdateAction.ReloadContent)
     }
     data class MenuColorMode(val value: Int) : ConfigUpdate {
-        override val actions = emptySet<ConfigUpdateAction>()
+        override val actions = setOf(ConfigUpdateAction.UpdateSystemUi)
     }
     data class ReadBarStyle(val value: Int) : ConfigUpdate {
-        override val actions = emptySet<ConfigUpdateAction>()
+        override val actions = setOf(ConfigUpdateAction.UpdateSystemUi)
     }
 
     // --- Menu bar border ---

--- a/app/src/main/java/io/legado/app/ui/book/read/ReadBookController.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/ReadBookController.kt
@@ -45,6 +45,7 @@ import io.legado.app.ui.book.read.page.provider.TextPageFactory
 import io.legado.app.ui.book.searchContent.SearchResult
 import io.legado.app.ui.login.SourceLoginJsExtensions
 import io.legado.app.ui.widget.PopupAction
+import io.legado.app.utils.ColorUtils
 import io.legado.app.utils.Debounce
 import io.legado.app.utils.GSON
 import io.legado.app.utils.buildMainHandler
@@ -231,6 +232,8 @@ class ReadBookController(
 
         if (toolBarHide) {
             activity.setLightStatusBar(ReadBookConfig.durConfig.curStatusIconDark())
+        } else {
+            activity.setLightStatusBar(ColorUtils.isColorLight(ReadBookConfig.resolvedMenuBgColor))
         }
     }
 

--- a/app/src/main/java/io/legado/app/ui/book/read/ReadBookViewModel.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/ReadBookViewModel.kt
@@ -2565,7 +2565,8 @@ class ReadBookViewModel(
             setOf(
                 ConfigUpdateAction.UpdateBackground,
                 ConfigUpdateAction.UpdateStyle,
-                ConfigUpdateAction.UpdateContent
+                ConfigUpdateAction.UpdateContent,
+                ConfigUpdateAction.UpdateSystemUi
             )
         ))
         postEvent(EventBus.UPDATE_READ_ACTION_BAR, true)

--- a/app/src/main/java/io/legado/app/ui/book/read/sheet/ReadStyleSheet.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/sheet/ReadStyleSheet.kt
@@ -97,7 +97,7 @@ fun ReadStyleContent(
     var currentPage by remember { mutableIntStateOf(0) }
 
     LaunchedEffect(pagerState) {
-        snapshotFlow { pagerState.settledPage }.collect { page ->
+        snapshotFlow { pagerState.currentPage }.collect { page ->
             currentPage = page
         }
     }


### PR DESCRIPTION
在readbookscreen，呼出菜单，切换日夜间模式、修改工具栏样式、切换布局或自定义菜单背景色，statusbar颜色没有同步刷新

如下截图

<img width="1080" height="2424" alt="Screenshot_20260608_000227" src="https://github.com/user-attachments/assets/9c8bd473-9dbd-47d6-8d4d-d31e749ad411" />