### PR TITLE
fix: ReadStyleContent切换Tab时高度跳变问题

### DIFF
--- a/app/src/main/java/io/legado/app/ui/book/read/sheet/ReadStyleSheet.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/sheet/ReadStyleSheet.kt
@@ -1,5 +1,6 @@
 package io.legado.app.ui.book.read.sheet
 
+import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -108,7 +109,9 @@ fun ReadStyleContent(
     ) {
         HorizontalPager(
             state = pagerState,
-            modifier = Modifier.weight(1f, fill = false),
+            modifier = Modifier
+                .weight(1f, fill = false)
+                .animateContentSize(),
         ) { page ->
             when (page) {
                 0 -> GlobalThemePage(
@@ -150,6 +153,7 @@ fun ReadStyleContent(
             selectedTabIndex = currentPage,
             onTabSelected = { index ->
                 if (index < 3) {
+                    currentPage = index
                     scope.launch { pagerState.animateScrollToPage(index) }
                 } else {
                     onOpenMoreConfig()

--- a/app/src/main/java/io/legado/app/ui/book/read/sheet/ReadStyleSheet.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/sheet/ReadStyleSheet.kt
@@ -153,7 +153,6 @@ fun ReadStyleContent(
             selectedTabIndex = currentPage,
             onTabSelected = { index ->
                 if (index < 3) {
-                    currentPage = index
                     scope.launch { pagerState.animateScrollToPage(index) }
                 } else {
                     onOpenMoreConfig()


### PR DESCRIPTION
<img width="1440" height="3200" alt="Screenshot_20260608_114808" src="https://github.com/user-attachments/assets/c3dd5635-10d8-4b8e-ba90-bc5c45dec434" />

page高度变化的时候，在过渡动画时CardTabRow位置不正确的问题