### PR TITLE
fix: 修复设置页面中开关状态未改变的问题

### DIFF
--- a/app/src/main/java/io/legado/app/ui/config/PrefDelegate.kt
+++ b/app/src/main/java/io/legado/app/ui/config/PrefDelegate.kt
@@ -118,7 +118,7 @@ fun <T> prefDelegate(
         }
 
         override fun getValue(thisRef: Any?, property: KProperty<*>): T {
-            return currentValue
+            return _value.value
         }
 
         override fun setValue(thisRef: Any?, property: KProperty<*>, value: T) {


### PR DESCRIPTION
1a99cdbac fix: 自动跳转最近阅读打开崩溃 这个commit

currentValue 不是一个state，导致Compose没有重组的问题

fix #1410 
