### PR TITLE
feat:调整AppSlider的默认滑块高度为32

### DIFF
--- a/app/src/main/java/io/legado/app/ui/widget/components/AppSlider.kt
+++ b/app/src/main/java/io/legado/app/ui/widget/components/AppSlider.kt
@@ -1,8 +1,13 @@
 package io.legado.app.ui.widget.components
 
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.height
 import androidx.compose.material3.Slider
+import androidx.compose.material3.SliderDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import io.legado.app.ui.theme.LegadoTheme.composeEngine
 import io.legado.app.ui.theme.ThemeResolver
 import top.yukonga.miuix.kmp.basic.Slider as MiuixSlider
@@ -28,6 +33,7 @@ fun AppSlider(
             onValueChangeFinished = onValueChangeFinished
         )
     } else {
+        val interactionSource = remember { MutableInteractionSource() }
         Slider(
             value = value,
             onValueChange = onValueChange,
@@ -35,7 +41,15 @@ fun AppSlider(
             enabled = enabled,
             valueRange = valueRange,
             steps = steps,
-            onValueChangeFinished = onValueChangeFinished
+            onValueChangeFinished = onValueChangeFinished,
+            interactionSource = interactionSource,
+            thumb = {
+                SliderDefaults.Thumb(
+                    interactionSource = interactionSource,
+                    modifier = Modifier.height(32.dp)
+                )
+            }
         )
     }
 }
+

--- a/app/src/main/java/io/legado/app/ui/widget/components/AppSlider.kt
+++ b/app/src/main/java/io/legado/app/ui/widget/components/AppSlider.kt
@@ -7,7 +7,9 @@ import androidx.compose.material3.SliderDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
+import coil.size.Size
 import io.legado.app.ui.theme.LegadoTheme.composeEngine
 import io.legado.app.ui.theme.ThemeResolver
 import top.yukonga.miuix.kmp.basic.Slider as MiuixSlider
@@ -46,7 +48,7 @@ fun AppSlider(
             thumb = {
                 SliderDefaults.Thumb(
                     interactionSource = interactionSource,
-                    modifier = Modifier.height(32.dp)
+                    thumbSize = DpSize(4.dp,32.dp)
                 )
             }
         )


### PR DESCRIPTION
https://github.com/HapeLee/legado-with-MD3/issues/1433#issuecomment-4701684349
默认SliderDefaults.Thumb高度44，感觉太高了，调短了一些