### PR TITLE
fix: 修复阅读菜单透明度失效

### DIFF
--- a/app/src/main/java/io/legado/app/help/config/AppConfig.kt
+++ b/app/src/main/java/io/legado/app/help/config/AppConfig.kt
@@ -125,7 +125,7 @@ object AppConfig : SharedPreferences.OnSharedPreferenceChangeListener {
         ReadConfig.pageTouchSlop = preferences.pageTouchSlop
         ReadConfig.showReadTitleAddition = preferences.showReadTitleAddition
         ReadConfig.titleBarMode = preferences.titleBarMode
-        ReadConfig.menuAlpha = preferences.menuAlpha
+        ReadConfig.readMenuBlurAlpha = preferences.readMenuBlurAlpha
         ReadConfig.readSliderMode = preferences.readSliderMode
         readBarStyleFollowPageValue = preferences.readBarStyleFollowPage
         readBarStyleValue = preferences.readBarStyle
@@ -837,9 +837,9 @@ object AppConfig : SharedPreferences.OnSharedPreferenceChangeListener {
             ThemeConfig.enableBlur = value
         }
     var menuAlpha: Int
-        get() = ReadConfig.menuAlpha
+        get() = ReadConfig.readMenuBlurAlpha
         set(value) {
-            ReadConfig.menuAlpha = value
+            ReadConfig.readMenuBlurAlpha = value
         }
 
     var readSliderMode

--- a/app/src/main/java/io/legado/app/help/config/AppConfig.kt
+++ b/app/src/main/java/io/legado/app/help/config/AppConfig.kt
@@ -836,6 +836,8 @@ object AppConfig : SharedPreferences.OnSharedPreferenceChangeListener {
         set(value) {
             ThemeConfig.enableBlur = value
         }
+
+    @Deprecated("Use ReadConfig.readMenuBlurAlpha instead", ReplaceWith("ReadConfig.readMenuBlurAlpha"))
     var menuAlpha: Int
         get() = ReadConfig.readMenuBlurAlpha
         set(value) {

--- a/app/src/main/java/io/legado/app/ui/book/read/ReadBookMenuBar.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/ReadBookMenuBar.kt
@@ -882,7 +882,7 @@ private fun MenuTitleBar(
                             progressive = topBarProgressiveBlur,
                         )
                 } else {
-                    Modifier.background(colors.background)
+                    Modifier.background(colors.background.copy(alpha = topBarAlpha))
                 }
             )
             .then(
@@ -1828,11 +1828,6 @@ private fun SearchBottomMenuContent(
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .background(
-                if (surfaceEffectEnabled) Color.Transparent else colors.background.copy(
-                    alpha = state.menuConfig.readMenuBlurAlpha.coerceIn(0, 100) / 100f
-                )
-            )
             .windowInsetsPadding(
                 WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal)
             )
@@ -2023,11 +2018,6 @@ private fun MenuBottomBar(
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .background(
-                if (surfaceEffectEnabled) Color.Transparent else colors.background.copy(
-                    alpha = state.menuConfig.readMenuBlurAlpha.coerceIn(0, 100) / 100f
-                )
-            )
             .windowInsetsPadding(
                 WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal)
             )

--- a/app/src/main/java/io/legado/app/ui/config/readConfig/ReadConfig.kt
+++ b/app/src/main/java/io/legado/app/ui/config/readConfig/ReadConfig.kt
@@ -130,7 +130,7 @@ object ReadConfig {
         expandTextMenu = preferences.expandTextMenu
         showReadTitleAddition = preferences.showReadTitleAddition
         titleBarMode = preferences.titleBarMode
-        menuAlpha = preferences.menuAlpha
+        readMenuBlurAlpha = preferences.readMenuBlurAlpha
         readSliderMode = preferences.readSliderMode
         readBarStyleFollowPage = preferences.readBarStyleFollowPage
         readBarStyle = preferences.readBarStyle
@@ -167,7 +167,7 @@ object ReadConfig {
 
     var titleBarMode: String = "1"
 
-    var menuAlpha: Int = 100
+    var readMenuBlurAlpha: Int = 60
 
     var readBodyToLh: Boolean = true
 

--- a/app/src/main/java/io/legado/app/ui/config/readConfig/ReadConfigContract.kt
+++ b/app/src/main/java/io/legado/app/ui/config/readConfig/ReadConfigContract.kt
@@ -7,7 +7,7 @@ data class ReadConfigUiState(
     val hideNavigationBar: Boolean = false,
     val paddingDisplayCutouts: Boolean = false,
     val titleBarMode: String = "1",
-    val menuAlpha: Int = 100,
+    val readMenuBlurAlpha: Int = 60,
     val readBodyToLh: Boolean = true,
     val defaultSourceChangeAll: Boolean = true,
     val textFullJustify: Boolean = true,
@@ -48,7 +48,7 @@ sealed interface ReadConfigIntent {
     data class HideNavigationBarChanged(val value: Boolean) : ReadConfigIntent
     data class PaddingDisplayCutoutsChanged(val value: Boolean) : ReadConfigIntent
     data class TitleBarModeChanged(val value: String) : ReadConfigIntent
-    data class MenuAlphaChanged(val value: Int) : ReadConfigIntent
+    data class ReadMenuBlurAlphaChanged(val value: Int) : ReadConfigIntent
     data class ReadBodyToLhChanged(val value: Boolean) : ReadConfigIntent
     data class DefaultSourceChangeAllChanged(val value: Boolean) : ReadConfigIntent
     data class TextFullJustifyChanged(val value: Boolean) : ReadConfigIntent

--- a/app/src/main/java/io/legado/app/ui/config/readConfig/ReadConfigScreen.kt
+++ b/app/src/main/java/io/legado/app/ui/config/readConfig/ReadConfigScreen.kt
@@ -115,12 +115,12 @@ fun ReadConfigScreen(
 
                 SliderSettingItem(
                     title = stringResource(R.string.menu_alpha),
-                    description = stringResource(R.string.menu_alpha_sum, state.menuAlpha),
-                    value = state.menuAlpha.toFloat(),
-                    defaultValue = 100f,
+                    description = stringResource(R.string.menu_alpha_sum, state.readMenuBlurAlpha),
+                    value = state.readMenuBlurAlpha.toFloat(),
+                    defaultValue = 60f,
                     valueRange = 0f..100f,
                     onValueChange = {
-                        viewModel.onIntent(ReadConfigIntent.MenuAlphaChanged(it.toInt()))
+                        viewModel.onIntent(ReadConfigIntent.ReadMenuBlurAlphaChanged(it.toInt()))
                     }
                 )
 

--- a/app/src/main/java/io/legado/app/ui/config/readConfig/ReadConfigViewModel.kt
+++ b/app/src/main/java/io/legado/app/ui/config/readConfig/ReadConfigViewModel.kt
@@ -59,9 +59,9 @@ class ReadConfigViewModel(
                     readSettingsRepository.setTitleBarMode(intent.value)
                 }
 
-                is ReadConfigIntent.MenuAlphaChanged -> {
-                    ReadConfig.menuAlpha = intent.value
-                    readSettingsRepository.setMenuAlpha(intent.value)
+                is ReadConfigIntent.ReadMenuBlurAlphaChanged -> {
+                    ReadConfig.readMenuBlurAlpha = intent.value
+                    readSettingsRepository.setReadMenuBlurAlpha(intent.value)
                     postEvent(EventBus.UPDATE_READ_ACTION_BAR, true)
                 }
 
@@ -230,7 +230,7 @@ class ReadConfigViewModel(
             hideNavigationBar = hideNavigationBar,
             paddingDisplayCutouts = paddingDisplayCutouts,
             titleBarMode = titleBarMode,
-            menuAlpha = menuAlpha,
+            readMenuBlurAlpha = readMenuBlurAlpha,
             readBodyToLh = readBodyToLh,
             defaultSourceChangeAll = defaultSourceChangeAll,
             textFullJustify = textFullJustify,


### PR DESCRIPTION
1. 没开模糊的情况下MenuTitleBar背景没有设置透明度
https://github.com/HapeLee/legado-with-MD3/blob/1ac93986a06fa406876ff88d792bfd4470978c55/app/src/main/java/io/legado/app/ui/book/read/ReadBookMenuBar.kt#L863-L884

2. MenuBottomBar设置了background，但是父容器也设置了，两个背景重叠了
https://github.com/HapeLee/legado-with-MD3/blob/1ac93986a06fa406876ff88d792bfd4470978c55/app/src/main/java/io/legado/app/ui/book/read/ReadBookMenuBar.kt#L558-L562

3. SearchBottomMenuContent 同上
4. ReadConfigScreen 设置菜单透明度没有生效，发现用的是menuAlpha这个字段，改成了readMenuBlurAlpha