### PR TITLE
fix：修复冷启动跳阅读页返回后状态栏不恢复的问题

### DIFF
--- a/app/src/main/java/io/legado/app/ui/config/themeConfig/ThemeConfigScreen.kt
+++ b/app/src/main/java/io/legado/app/ui/config/themeConfig/ThemeConfigScreen.kt
@@ -5,7 +5,6 @@ import android.content.Context
 import android.content.Intent
 import android.os.Handler
 import android.os.Looper
-import android.widget.TextView
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedVisibility
@@ -60,7 +59,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringArrayResource
@@ -72,7 +70,6 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.core.net.toUri
-
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import io.legado.app.R
 import io.legado.app.base.AppContextWrapper
@@ -80,7 +77,6 @@ import io.legado.app.constant.EventBus
 import io.legado.app.constant.PreferKey
 import io.legado.app.help.LauncherIconHelp
 import io.legado.app.help.config.ThemeConfigStore
-import io.legado.app.help.loadFontFiles
 import io.legado.app.ui.config.labConfig.LabConfig
 import io.legado.app.ui.theme.LegadoTheme
 import io.legado.app.ui.theme.ThemeEngine
@@ -92,7 +88,6 @@ import io.legado.app.ui.widget.components.SplicedColumnGroup
 import io.legado.app.ui.widget.components.alert.AppAlertDialog
 import io.legado.app.ui.widget.components.button.series.SmallPlainButton
 import io.legado.app.ui.widget.components.card.GlassCard
-import io.legado.app.ui.widget.components.card.NormalCard
 import io.legado.app.ui.widget.components.dialog.ColorPickerSheet
 import io.legado.app.ui.widget.components.icon.AppIcons
 import io.legado.app.ui.widget.components.settingItem.ClickableSettingItem
@@ -397,7 +392,10 @@ fun ThemeConfigScreen(
                     SwitchSettingItem(
                         title = stringResource(R.string.show_status),
                         checked = ThemeConfig.showStatusBar,
-                        onCheckedChange = { ThemeConfig.showStatusBar = it }
+                        onCheckedChange = {
+                            ThemeConfig.showStatusBar = it
+                            postEvent(EventBus.NOTIFY_MAIN, true)
+                        }
                     )
                     //TODO:这个可以不要了，在删掉原来的设置页以后删
                     SwitchSettingItem(

--- a/app/src/main/java/io/legado/app/ui/main/MainNavGraph.kt
+++ b/app/src/main/java/io/legado/app/ui/main/MainNavGraph.kt
@@ -19,6 +19,7 @@ import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.ui.LocalNavAnimatedContentScope
 import androidx.navigation3.ui.NavDisplay
+import io.legado.app.help.config.AppConfig
 import io.legado.app.model.Download
 import io.legado.app.ui.about.AboutEffect
 import io.legado.app.ui.about.AboutScreen
@@ -65,6 +66,7 @@ import io.legado.app.utils.openUrl
 import io.legado.app.utils.startActivity
 import io.legado.app.utils.startActivityForBook
 import io.legado.app.utils.toastOnUi
+import io.legado.app.utils.toggleSystemBar
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.coroutines.flow.collectLatest
@@ -341,6 +343,7 @@ fun MainActivity.mainEntryProvider(
                 }
                 MainActivity.hasActiveReadBookRoute = false
                 controller.clearTts()
+                this@mainEntryProvider.toggleSystemBar(AppConfig.showStatusBar)
             }
         }
 


### PR DESCRIPTION
我设置了自动跳转最近阅读 ，然后阅读界面设置隐藏状态栏，冷启动的时候自动跳到阅读页，然后返回，没有恢复状态栏的逻辑


https://github.com/user-attachments/assets/3abac715-0d1a-446b-96a5-388d75669be3

最后阅读的shortcut启动应该也可以复现这个问题

然后又挖出设置页显示状态栏的开关没有立即生效的问题，也一并改了