### PR TITLE
fix: 修复小窗模式返回全屏时尺寸问题

### DIFF
--- a/app/src/main/java/io/legado/app/model/ReadBook.kt
+++ b/app/src/main/java/io/legado/app/model/ReadBook.kt
@@ -643,12 +643,16 @@ object ReadBook : CoroutineScope by MainScope(), KoinComponent {
      * chapterOnDur: 0为当前页,1为下一页,-1为上一页
      */
     fun textChapter(chapterOnDur: Int = 0): TextChapter? {
-        return when (chapterOnDur) {
+        val chapter = when (chapterOnDur) {
             0 -> curTextChapter
             1 -> nextTextChapter
             -1 -> prevTextChapter
             else -> null
         }
+        if (chapter != null && !chapter.isLayoutSizeMatch()) {
+            return null
+        }
+        return chapter
     }
 
     /**
@@ -668,17 +672,25 @@ object ReadBook : CoroutineScope by MainScope(), KoinComponent {
     }
 
     fun loadOrUpContent(success: (() -> Unit)? = null) {
-        if (curTextChapter == null) {
+        val curChapter = curTextChapter
+        if (curChapter == null || !curChapter.isLayoutSizeMatch()) {
+            curTextChapter = null
+            nextTextChapter = null
+            prevTextChapter = null
             loadContent(durChapterIndex) {
                 success?.invoke()
             }
         } else {
             callBack?.upContent()
         }
-        if (nextTextChapter == null) {
+        val nextChapter = nextTextChapter
+        if (nextChapter == null || !nextChapter.isLayoutSizeMatch()) {
+            nextTextChapter = null
             loadContent(durChapterIndex + 1)
         }
-        if (prevTextChapter == null) {
+        val prevChapter = prevTextChapter
+        if (prevChapter == null || !prevChapter.isLayoutSizeMatch()) {
+            prevTextChapter = null
             loadContent(durChapterIndex - 1)
         }
     }

--- a/app/src/main/java/io/legado/app/ui/book/read/page/entities/TextChapter.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/page/entities/TextChapter.kt
@@ -8,6 +8,7 @@ import io.legado.app.data.entities.ReplaceRule
 import io.legado.app.help.book.BookContent
 import io.legado.app.ui.book.read.page.provider.LayoutProgressListener
 import io.legado.app.ui.book.read.page.provider.TextChapterLayout
+import io.legado.app.ui.book.read.page.provider.ChapterProvider
 import io.legado.app.utils.fastBinarySearchBy
 import kotlinx.coroutines.CoroutineScope
 import kotlin.math.abs
@@ -29,6 +30,15 @@ data class TextChapter(
     //起效的替换规则
     val effectiveReplaceRules: List<ReplaceRule>?
 ) : LayoutProgressListener {
+
+    var visibleWidth: Int = 0
+        private set
+    var visibleHeight: Int = 0
+        private set
+
+    fun isLayoutSizeMatch(): Boolean {
+        return visibleWidth == ChapterProvider.visibleWidth && visibleHeight == ChapterProvider.visibleHeight
+    }
 
     private val textPages = arrayListOf<TextPage>()
     val pages: List<TextPage> get() = textPages
@@ -269,13 +279,16 @@ data class TextChapter(
         if (layout != null) {
             throw IllegalStateException("已经排版过了")
         }
-        layout = TextChapterLayout(
+        val textLayout = TextChapterLayout(
             scope,
             this,
             textPages,
             book,
             bookContent,
         )
+        layout = textLayout
+        visibleWidth = textLayout.visibleWidth
+        visibleHeight = textLayout.visibleHeight
     }
 
     fun setProgressListener(l: LayoutProgressListener?) {

--- a/app/src/main/java/io/legado/app/ui/book/read/page/entities/TextChapter.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/page/entities/TextChapter.kt
@@ -31,8 +31,10 @@ data class TextChapter(
     val effectiveReplaceRules: List<ReplaceRule>?
 ) : LayoutProgressListener {
 
+    @Volatile
     var visibleWidth: Int = 0
         private set
+    @Volatile
     var visibleHeight: Int = 0
         private set
 

--- a/app/src/main/java/io/legado/app/ui/book/read/page/provider/TextChapterLayout.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/page/provider/TextChapterLayout.kt
@@ -128,8 +128,8 @@ class TextChapterLayout(
     private val lineSpacingExtra = ChapterProvider.lineSpacingExtra
     private val paragraphSpacing = ChapterProvider.paragraphSpacing
 
-    private val visibleHeight = ChapterProvider.visibleHeight
-    private val visibleWidth = ChapterProvider.visibleWidth
+    internal val visibleHeight = ChapterProvider.visibleHeight
+    internal val visibleWidth = ChapterProvider.visibleWidth
 
     private val viewWidth = ChapterProvider.viewWidth
     private val doublePage = ChapterProvider.doublePage


### PR DESCRIPTION
在小窗或者分屏的时候再回到全屏
在一些设备上会出现文字排版未更新成最新尺寸的问题

<img width="1440" height="3088" alt="微信图片_20260616164502_14332_2" src="https://github.com/user-attachments/assets/31e55efd-d92c-4c1c-923e-262bdbef70c2" />

loadOrUpContent取的curTextChapter，是小窗时的缓存