### PR TITLE
fix：阅读界面切换深浅色，底部菜单高度抖动的问题

### DIFF
--- a/app/src/main/java/io/legado/app/ui/book/read/ReadBookMenuBar.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/ReadBookMenuBar.kt
@@ -101,6 +101,7 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.layout
 import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
@@ -411,8 +412,9 @@ private fun ReadBookMenuSurface(
         560.dp
     }
     val isFloating = state.menuConfig.readMenuFloatingBottomBar
+    val orientation = LocalConfiguration.current.orientation
     val currentNavBarHeight = with(density) { WindowInsets.navigationBars.getBottom(this).toDp() }
-    var lastValidNavBarHeightValue by rememberSaveable { mutableFloatStateOf(currentNavBarHeight.value) }
+    var lastValidNavBarHeightValue by rememberSaveable(orientation) { mutableFloatStateOf(currentNavBarHeight.value) }
     SideEffect {
         if (currentNavBarHeight.value > 0f) {
             lastValidNavBarHeightValue = currentNavBarHeight.value

--- a/app/src/main/java/io/legado/app/ui/book/read/ReadBookMenuBar.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/ReadBookMenuBar.kt
@@ -71,7 +71,6 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableIntStateOf
@@ -415,10 +414,8 @@ private fun ReadBookMenuSurface(
     val orientation = LocalConfiguration.current.orientation
     val currentNavBarHeight = with(density) { WindowInsets.navigationBars.getBottom(this).toDp() }
     var lastValidNavBarHeightValue by rememberSaveable(orientation) { mutableFloatStateOf(currentNavBarHeight.value) }
-    SideEffect {
-        if (currentNavBarHeight.value > 0f) {
-            lastValidNavBarHeightValue = currentNavBarHeight.value
-        }
+    if (currentNavBarHeight.value > 0f && lastValidNavBarHeightValue != currentNavBarHeight.value) {
+        lastValidNavBarHeightValue = currentNavBarHeight.value
     }
     val navBarHeight = if (currentNavBarHeight.value > 0f) currentNavBarHeight else lastValidNavBarHeightValue.dp
     val floatingHorizontalMargin = if (isFloating) 16.dp else 0.dp

--- a/app/src/main/java/io/legado/app/ui/book/read/ReadBookMenuBar.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/ReadBookMenuBar.kt
@@ -79,6 +79,7 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
@@ -411,7 +412,12 @@ private fun ReadBookMenuSurface(
         560.dp
     }
     val isFloating = state.menuConfig.readMenuFloatingBottomBar
-    val navBarHeight = with(density) { WindowInsets.navigationBars.getBottom(this).toDp() }
+    val currentNavBarHeight = with(density) { WindowInsets.navigationBars.getBottom(this).toDp() }
+    var maxNavBarHeightValue by rememberSaveable { mutableFloatStateOf(0f) }
+    if (currentNavBarHeight.value > maxNavBarHeightValue) {
+        maxNavBarHeightValue = currentNavBarHeight.value
+    }
+    val navBarHeight = if (currentNavBarHeight.value > 0f) currentNavBarHeight else maxNavBarHeightValue.dp
     val floatingHorizontalMargin = if (isFloating) 16.dp else 0.dp
     val floatingBottomMargin = if (isFloating) 16.dp + navBarHeight else 0.dp
     val mainHorizontalMargin =

--- a/app/src/main/java/io/legado/app/ui/book/read/ReadBookMenuBar.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/ReadBookMenuBar.kt
@@ -6,10 +6,8 @@ import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.SizeTransform
 import androidx.compose.animation.animateContentSize
-import androidx.compose.animation.core.LinearOutSlowInEasing
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInHorizontally
@@ -73,6 +71,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableIntStateOf
@@ -413,11 +412,13 @@ private fun ReadBookMenuSurface(
     }
     val isFloating = state.menuConfig.readMenuFloatingBottomBar
     val currentNavBarHeight = with(density) { WindowInsets.navigationBars.getBottom(this).toDp() }
-    var maxNavBarHeightValue by rememberSaveable { mutableFloatStateOf(0f) }
-    if (currentNavBarHeight.value > maxNavBarHeightValue) {
-        maxNavBarHeightValue = currentNavBarHeight.value
+    var lastValidNavBarHeightValue by rememberSaveable { mutableFloatStateOf(currentNavBarHeight.value) }
+    SideEffect {
+        if (currentNavBarHeight.value > 0f) {
+            lastValidNavBarHeightValue = currentNavBarHeight.value
+        }
     }
-    val navBarHeight = if (currentNavBarHeight.value > 0f) currentNavBarHeight else maxNavBarHeightValue.dp
+    val navBarHeight = if (currentNavBarHeight.value > 0f) currentNavBarHeight else lastValidNavBarHeightValue.dp
     val floatingHorizontalMargin = if (isFloating) 16.dp else 0.dp
     val floatingBottomMargin = if (isFloating) 16.dp + navBarHeight else 0.dp
     val mainHorizontalMargin =


### PR DESCRIPTION

https://github.com/user-attachments/assets/19691582-a530-431d-8454-01ec839579bb

<img width="1456" height="233" alt="ScreenShot_2026-06-17_224913_773" src="https://github.com/user-attachments/assets/8eac2205-c8fd-45cb-869a-4c064bf61751" />

切换深浅色后，navigationBar高度会变成0，导致菜单高度跳了

ReadMenuSlider状态也有问题，感觉像是和分页排版那的逻辑有关