### PR TITLE
fix：页眉页脚翻页信息抖动问题

### DIFF
--- a/app/src/main/java/io/legado/app/ui/book/read/page/PageView.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/page/PageView.kt
@@ -470,6 +470,7 @@ class PageView(
             tvPageAndTotal?.setTextIfNotEqual("${index.plus(1)}/$pageSize  $readProgress")
             tvPage?.setTextIfNotEqual("${index.plus(1)}/$pageSize")
         }
+        this@PageView.layoutSync()
     }
 
     fun layoutSync() {
@@ -485,7 +486,6 @@ class PageView(
     fun screenshot(canvasRecorder: CanvasRecorder) {
         if (!isMainView && !isScroll) {
             setProgress(textPage)
-            layoutSync()
         }
         viewScreenshot(canvasRecorder)
     }
@@ -493,7 +493,6 @@ class PageView(
     fun screenshot(bitmap: Bitmap? = null, canvas: Canvas? = null): Bitmap? {
         if (!isMainView && !isScroll) {
             setProgress(textPage)
-            layoutSync()
         }
         return viewScreenshot(bitmap, canvas)
     }


### PR DESCRIPTION
宽度变化明显的情况下，例如 “9/15” -> “10/15” ，抖动的情况依然复现