### PR TITLE
feat: 增加是否展示菜单项图标的配置开关

### DIFF
--- a/app/src/main/java/io/legado/app/constant/PreferKey.kt
+++ b/app/src/main/java/io/legado/app/constant/PreferKey.kt
@@ -318,6 +318,7 @@ object PreferKey {
     const val titleBarCustomIcons = "titleBarCustomIcons"
     const val titleBarIconPosition = "titleBarIconPosition"
     const val showTitleBarIcons = "showTitleBarIcons"
+    const val showMenuIcon = "showMenuIcon"
     const val disableReturnKey = "disableReturnKey"
     const val selectText = "selectText"
     //我在干什么

--- a/app/src/main/java/io/legado/app/data/repository/ReadSettingsRepository.kt
+++ b/app/src/main/java/io/legado/app/data/repository/ReadSettingsRepository.kt
@@ -105,6 +105,7 @@ data class ReadPreferences(
     val titleBarIconPosition: Int = 0,
     val showTitleBarIcons: Boolean = true,
     val chineseConverterType: Int = 0,
+    val showMenuIcon: Boolean = true,
 )
 
 class ReadSettingsRepository(
@@ -367,6 +368,9 @@ class ReadSettingsRepository(
     suspend fun setShowTitleBarIcons(value: Boolean) =
         settingsRepository.putBoolean(PreferKey.showTitleBarIcons, value)
 
+    suspend fun setShowMenuIcon(value: Boolean) =
+        settingsRepository.putBoolean(PreferKey.showMenuIcon, value)
+
     suspend fun setChineseConverterType(value: Int) =
         settingsRepository.putInt(PreferKey.chineseConverterType, value)
 
@@ -471,9 +475,9 @@ class ReadSettingsRepository(
             readMenuBorderColorNight = this[Keys.ReadMenuBorderColorNight] ?: 0,
             readMenuCustomIcons = this[Keys.ReadMenuCustomIcons] ?: "",
             titleBarCustomIcons = this[Keys.TitleBarCustomIcons] ?: "",
-            titleBarIconPosition = this[Keys.TitleBarIconPosition] ?: 0,
             showTitleBarIcons = this[Keys.ShowTitleBarIcons] ?: false,
             chineseConverterType = this[Keys.ChineseConverterType] ?: 0,
+            showMenuIcon = this[Keys.ShowMenuIcon] ?: true,
         )
     }
 
@@ -570,5 +574,6 @@ class ReadSettingsRepository(
         val TitleBarIconPosition = intPreferencesKey(PreferKey.titleBarIconPosition)
         val ShowTitleBarIcons = booleanPreferencesKey(PreferKey.showTitleBarIcons)
         val ChineseConverterType = intPreferencesKey(PreferKey.chineseConverterType)
+        val ShowMenuIcon = booleanPreferencesKey(PreferKey.showMenuIcon)
     }
 }

--- a/app/src/main/java/io/legado/app/data/repository/ReadSettingsRepository.kt
+++ b/app/src/main/java/io/legado/app/data/repository/ReadSettingsRepository.kt
@@ -475,6 +475,7 @@ class ReadSettingsRepository(
             readMenuBorderColorNight = this[Keys.ReadMenuBorderColorNight] ?: 0,
             readMenuCustomIcons = this[Keys.ReadMenuCustomIcons] ?: "",
             titleBarCustomIcons = this[Keys.TitleBarCustomIcons] ?: "",
+            titleBarIconPosition = this[Keys.TitleBarIconPosition] ?: 0,
             showTitleBarIcons = this[Keys.ShowTitleBarIcons] ?: false,
             chineseConverterType = this[Keys.ChineseConverterType] ?: 0,
             showMenuIcon = this[Keys.ShowMenuIcon] ?: true,

--- a/app/src/main/java/io/legado/app/help/config/ReadBookConfig.kt
+++ b/app/src/main/java/io/legado/app/help/config/ReadBookConfig.kt
@@ -202,6 +202,7 @@ object ReadBookConfig {
     var hideNavigationBar by prefDelegate(PreferKey.hideNavigationBar, false)
     var useZhLayout by prefDelegate(PreferKey.useZhLayout, false)
     var readMenuIconShowText by prefDelegate(PreferKey.readMenuIconShowText, true)
+    var showMenuIcon by prefDelegate(PreferKey.showMenuIcon, true)
     var readMenuFloatingBottomBar by prefDelegate(PreferKey.readMenuFloatingBottomBar, false)
     var readMenuTopBarLiquidGlassButtons by prefDelegate(PreferKey.readMenuTopBarLiquidGlassButtons, false)
     var readMenuTopBarTitleCapsule by prefDelegate(PreferKey.readMenuTopBarTitleCapsule, false)

--- a/app/src/main/java/io/legado/app/ui/book/read/ReadBookContract.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/ReadBookContract.kt
@@ -208,6 +208,7 @@ data class ReadMenuConfig(
     val brightnessVwPos: String = "1",
     val readBrightness: Int = 100,
     val brightnessAuto: Boolean = false,
+    val showMenuIcon: Boolean = true,
 )
 
 @Immutable
@@ -1106,6 +1107,9 @@ sealed interface ConfigUpdate {
         override val actions = setOf(ConfigUpdateAction.UpdateStyle)
     }
     data class TitleBarMode(val value: String) : ConfigUpdate {
+        override val actions = emptySet<ConfigUpdateAction>()
+    }
+    data class ShowMenuIcon(val value: Boolean) : ConfigUpdate {
         override val actions = emptySet<ConfigUpdateAction>()
     }
     data class ReadBodyToLh(val value: Boolean) : ConfigUpdate {

--- a/app/src/main/java/io/legado/app/ui/book/read/ReadBookMenuBar.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/ReadBookMenuBar.kt
@@ -69,6 +69,19 @@ import androidx.compose.material.icons.filled.Payment
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.SwapHoriz
+import androidx.compose.material.icons.filled.Animation
+import androidx.compose.material.icons.filled.AutoStories
+import androidx.compose.material.icons.filled.Bookmark
+import androidx.compose.material.icons.filled.Build
+import androidx.compose.material.icons.filled.CleanHands
+import androidx.compose.material.icons.filled.CloudDownload
+import androidx.compose.material.icons.filled.FindReplace
+import androidx.compose.material.icons.filled.Image
+import androidx.compose.material.icons.filled.Rule
+import androidx.compose.material.icons.filled.SwapVert
+import androidx.compose.material.icons.filled.Sync
+import androidx.compose.material.icons.filled.Toc
+import androidx.compose.material.icons.filled.Translate
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -157,6 +170,7 @@ import io.legado.app.ui.widget.components.AppVerticalSlider
 import io.legado.app.ui.widget.components.bookmark.BookmarkEditContent
 import io.legado.app.ui.widget.components.button.series.SmallTonalButton
 import io.legado.app.ui.widget.components.divider.PillDivider
+import io.legado.app.ui.widget.components.icon.AppIcons
 import io.legado.app.ui.widget.components.menuItem.MenuItemIcon
 import io.legado.app.ui.widget.components.menuItem.RoundDropdownMenu
 import io.legado.app.ui.widget.components.menuItem.RoundDropdownMenuItem
@@ -1624,6 +1638,15 @@ private fun OverflowDropdownMenu(
     expanded: Boolean,
     onDismiss: () -> Unit,
 ) {
+    val showIcon = state.menuConfig.showMenuIcon
+    val menuIcon: (ImageVector) -> (@Composable () -> Unit)? = { imageVector ->
+        if (showIcon) {
+            { MenuItemIcon(imageVector = imageVector) }
+        } else {
+            null
+        }
+    }
+
     RoundDropdownMenu(
         expanded = expanded,
         onDismissRequest = onDismiss,
@@ -1634,6 +1657,7 @@ private fun OverflowDropdownMenu(
         if (!state.isLocalBook) {
             RoundDropdownMenuItem(
                 text = stringResource(R.string.menu_refresh_all),
+                leadingIcon = menuIcon(AppIcons.Replay),
                 onClick = { dismiss(); onIntent(ReadBookIntent.MenuRefreshAll) },
             )
         }
@@ -1642,6 +1666,7 @@ private fun OverflowDropdownMenu(
         if (state.isLocalTxt) {
             RoundDropdownMenuItem(
                 text = stringResource(R.string.txt_toc_rule),
+                leadingIcon = menuIcon(Icons.Default.Toc),
                 onClick = { dismiss(); onIntent(ReadBookIntent.MenuTocRegex) },
             )
         }
@@ -1650,6 +1675,7 @@ private fun OverflowDropdownMenu(
         if (state.isLocalBook) {
             RoundDropdownMenuItem(
                 text = stringResource(R.string.set_charset),
+                leadingIcon = menuIcon(Icons.Default.Translate),
                 onClick = {
                     dismiss()
                     onIntent(ReadBookIntent.ShowSheet(ReadBookSheet.Charset))
@@ -1662,10 +1688,12 @@ private fun OverflowDropdownMenu(
         // Content operations
         RoundDropdownMenuItem(
             text = stringResource(R.string.bookmark_add),
+            leadingIcon = menuIcon(Icons.Default.Bookmark),
             onClick = { dismiss(); onIntent(ReadBookIntent.AddBookmark) },
         )
         RoundDropdownMenuItem(
             text = stringResource(R.string.edit_content),
+            leadingIcon = menuIcon(AppIcons.Edit),
             onClick = {
                 dismiss()
                 onIntent(ReadBookIntent.ShowSheet(ReadBookSheet.ContentEdit))
@@ -1674,6 +1702,7 @@ private fun OverflowDropdownMenu(
         if (!state.isLocalBook) {
             RoundDropdownMenuItem(
                 text = stringResource(R.string.offline_cache),
+                leadingIcon = menuIcon(Icons.Default.CloudDownload),
                 onClick = {
                     dismiss()
                     onIntent(ReadBookIntent.ShowSheet(ReadBookSheet.Download))
@@ -1682,10 +1711,12 @@ private fun OverflowDropdownMenu(
         }
         RoundDropdownMenuItem(
             text = stringResource(R.string.update_toc),
+            leadingIcon = menuIcon(AppIcons.Replay),
             onClick = { dismiss(); onIntent(ReadBookIntent.MenuUpdateToc) },
         )
         RoundDropdownMenuItem(
             text = stringResource(R.string.simulated_reading),
+            leadingIcon = menuIcon(Icons.Default.AutoStories),
             onClick = {
                 dismiss()
                 onIntent(ReadBookIntent.ShowSheet(ReadBookSheet.SimulatedReading))
@@ -1693,6 +1724,7 @@ private fun OverflowDropdownMenu(
         )
         RoundDropdownMenuItem(
             text = stringResource(R.string.reverse_content),
+            leadingIcon = menuIcon(Icons.Default.SwapVert),
             onClick = { dismiss(); onIntent(ReadBookIntent.MenuReverseContent) },
         )
 
@@ -1701,15 +1733,18 @@ private fun OverflowDropdownMenu(
         // Checkable items
         RoundDropdownMenuItem(
             text = stringResource(R.string.replace_rule_title),
+            leadingIcon = menuIcon(Icons.Default.FindReplace),
             isSelected = state.useReplaceRule,
             onClick = { onIntent(ReadBookIntent.MenuEnableReplace) },
         )
         RoundDropdownMenuItem(
             text = stringResource(R.string.replace_rule_title_setting),
+            leadingIcon = menuIcon(AppIcons.Settings),
             onClick = { dismiss(); onIntent(ReadBookIntent.MenuSettingReplace) },
         )
         RoundDropdownMenuItem(
             text = stringResource(R.string.effective_replaces),
+            leadingIcon = menuIcon(Icons.Default.Rule),
             onClick = {
                 dismiss()
                 onIntent(ReadBookIntent.ShowSheet(ReadBookSheet.EffectiveReplaces))
@@ -1717,11 +1752,13 @@ private fun OverflowDropdownMenu(
         )
         RoundDropdownMenuItem(
             text = stringResource(R.string.same_title_removed),
+            leadingIcon = menuIcon(Icons.Default.CleanHands),
             isSelected = state.sameTitleRemoved,
             onClick = { onIntent(ReadBookIntent.MenuSameTitleRemoved) },
         )
         RoundDropdownMenuItem(
             text = stringResource(R.string.re_segment),
+            leadingIcon = menuIcon(Icons.Default.Toc),
             isSelected = state.reSegment,
             onClick = { onIntent(ReadBookIntent.MenuReSegment) },
         )
@@ -1730,11 +1767,13 @@ private fun OverflowDropdownMenu(
         if (state.isEpub) {
             RoundDropdownMenuItem(
                 text = stringResource(R.string.del_ruby_tag),
+                leadingIcon = menuIcon(Icons.Default.CleanHands),
                 isSelected = state.delRubyTag,
                 onClick = { onIntent(ReadBookIntent.MenuDelRubyTag) },
             )
             RoundDropdownMenuItem(
                 text = stringResource(R.string.del_h_tag),
+                leadingIcon = menuIcon(Icons.Default.CleanHands),
                 isSelected = state.delHTag,
                 onClick = { onIntent(ReadBookIntent.MenuDelHTag) },
             )
@@ -1746,6 +1785,7 @@ private fun OverflowDropdownMenu(
         Box {
             RoundDropdownMenuItem(
                 text = stringResource(R.string.image_style),
+                leadingIcon = menuIcon(Icons.Default.Image),
                 onClick = { imageStyleExpanded = true },
             )
             RoundDropdownMenu(
@@ -1784,6 +1824,7 @@ private fun OverflowDropdownMenu(
         }
         RoundDropdownMenuItem(
             text = stringResource(R.string.book_page_anim),
+            leadingIcon = menuIcon(Icons.Default.Animation),
             onClick = {
                 dismiss()
                 onIntent(ReadBookIntent.ShowSheet(ReadBookSheet.PageAnim))
@@ -1791,6 +1832,7 @@ private fun OverflowDropdownMenu(
         )
         RoundDropdownMenuItem(
             text = stringResource(R.string.config_btn),
+            leadingIcon = menuIcon(Icons.Default.Build),
             onClick = {
                 dismiss()
                 onIntent(ReadBookIntent.ShowSheet(ReadBookSheet.ToolButtonConfig))
@@ -1801,10 +1843,12 @@ private fun OverflowDropdownMenu(
         if (state.isReadingProgressSyncConfigured) {
             RoundDropdownMenuItem(
                 text = stringResource(R.string.get_book_progress),
+                leadingIcon = menuIcon(Icons.Default.Sync),
                 onClick = { dismiss(); onIntent(ReadBookIntent.MenuGetProgress) },
             )
             RoundDropdownMenuItem(
                 text = stringResource(R.string.cover_book_progress),
+                leadingIcon = menuIcon(Icons.Default.Sync),
                 onClick = { dismiss(); onIntent(ReadBookIntent.MenuCoverProgress) },
             )
         }
@@ -1813,6 +1857,7 @@ private fun OverflowDropdownMenu(
 
         RoundDropdownMenuItem(
             text = stringResource(R.string.log),
+            leadingIcon = menuIcon(AppIcons.BugReport),
             onClick = {
                 dismiss()
                 onIntent(ReadBookIntent.ShowSheet(ReadBookSheet.AppLog))

--- a/app/src/main/java/io/legado/app/ui/book/read/ReadBookViewModel.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/ReadBookViewModel.kt
@@ -1677,6 +1677,7 @@ class ReadBookViewModel(
                 ReadConfig.syncReadPreferences(preferences)
                 ReadBookConfig.readMenuPaletteStyle = preferences.readMenuPaletteStyle
                 _readPreferences.value = preferences
+                _uiState.update { syncFromReadBook(it) }
                 if (!preferences.hasMenuClickArea()) {
                     ReadConfig.detectClickArea()
                     readSettingsRepository.setClickAction(PreferKey.clickActionMC, 0)
@@ -1847,6 +1848,7 @@ class ReadBookViewModel(
                 brightnessVwPos = ReadBookConfig.brightnessVwPos,
                 readBrightness = ReadBookConfig.readBrightness,
                 brightnessAuto = ReadBookConfig.brightnessAuto,
+                showMenuIcon = ReadBookConfig.showMenuIcon,
             ),
         )
     }
@@ -3037,6 +3039,13 @@ class ReadBookViewModel(
                         )
                     )
                 }
+            }
+            is ConfigUpdate.ShowMenuIcon -> {
+                ReadBookConfig.showMenuIcon = update.value
+                viewModelScope.launch {
+                    readSettingsRepository.setShowMenuIcon(update.value)
+                }
+                _uiState.update { it.copy(menuConfig = it.menuConfig.copy(showMenuIcon = update.value)) }
             }
             is ConfigUpdate.MenuTopBarBlurMode -> {
                 val mode = update.value.coerceIn(0, 2).let {

--- a/app/src/main/java/io/legado/app/ui/book/read/sheet/MoreConfigSheet.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/sheet/MoreConfigSheet.kt
@@ -147,6 +147,9 @@ fun MoreConfigSheet(
                 onShowReadTitleAdditionChange = {
                     onIntent(ReadBookIntent.UpdateConfig(ConfigUpdate.ShowReadTitleAddition(it)))
                 },
+                onShowMenuIconChange = {
+                    onIntent(ReadBookIntent.UpdateConfig(ConfigUpdate.ShowMenuIcon(it)))
+                },
             )
         }
     }
@@ -299,6 +302,7 @@ private fun OtherSettings(
     onOpenPageKeyConfig: () -> Unit,
     onExpandTextMenuChange: (Boolean) -> Unit,
     onShowReadTitleAdditionChange: (Boolean) -> Unit,
+    onShowMenuIconChange: (Boolean) -> Unit,
 ) {
     val clickImageWayEntries = stringArrayResource(R.array.click_image_way_title)
     val clickImageWayValues = stringArrayResource(R.array.click_image_way_value)
@@ -362,5 +366,10 @@ private fun OtherSettings(
         title = stringResource(R.string.show_read_title_addition),
         checked = preferences.showReadTitleAddition,
         onCheckedChange = onShowReadTitleAdditionChange,
+    )
+    TinySwitchSettingItem(
+        title = stringResource(R.string.show_menu_icon),
+        checked = preferences.showMenuIcon,
+        onCheckedChange = onShowMenuIconChange,
     )
 }

--- a/app/src/main/java/io/legado/app/ui/config/readConfig/ReadConfig.kt
+++ b/app/src/main/java/io/legado/app/ui/config/readConfig/ReadConfig.kt
@@ -87,6 +87,9 @@ object ReadConfig {
     var showReadTitleAddition
         get() = ReadMenuConfig.showReadTitleAddition
         set(value) { ReadMenuConfig.showReadTitleAddition = value }
+    var showMenuIcon
+        get() = ReadMenuConfig.showMenuIcon
+        set(value) { ReadMenuConfig.showMenuIcon = value }
     var clickActionTL
         get() = ReadMenuConfig.clickActionTL
         set(value) { ReadMenuConfig.clickActionTL = value }
@@ -262,6 +265,7 @@ object ReadConfig {
             progressBarBehavior = preferences.progressBarBehavior
             expandTextMenu = preferences.expandTextMenu
             showReadTitleAddition = preferences.showReadTitleAddition
+            showMenuIcon = preferences.showMenuIcon
             clickActionTL = preferences.clickActionTL
             clickActionTC = preferences.clickActionTC
             clickActionTR = preferences.clickActionTR

--- a/app/src/main/java/io/legado/app/ui/config/readConfig/ReadConfigContract.kt
+++ b/app/src/main/java/io/legado/app/ui/config/readConfig/ReadConfigContract.kt
@@ -38,7 +38,8 @@ data class ReadConfigUiState(
     val showReadTitleAddition: Boolean = true,
     val autoReadSpeed: Int = 10,
     val prevKeys: String = "",
-    val nextKeys: String = ""
+    val nextKeys: String = "",
+    val showMenuIcon: Boolean = true
 )
 
 sealed interface ReadConfigIntent {
@@ -76,5 +77,6 @@ sealed interface ReadConfigIntent {
     data class DisableReturnKeyChanged(val value: Boolean) : ReadConfigIntent
     data class ExpandTextMenuChanged(val value: Boolean) : ReadConfigIntent
     data class ShowReadTitleAdditionChanged(val value: Boolean) : ReadConfigIntent
+    data class ShowMenuIconChanged(val value: Boolean) : ReadConfigIntent
     data class PageKeysChanged(val prevKeys: String, val nextKeys: String) : ReadConfigIntent
 }

--- a/app/src/main/java/io/legado/app/ui/config/readConfig/ReadConfigScreen.kt
+++ b/app/src/main/java/io/legado/app/ui/config/readConfig/ReadConfigScreen.kt
@@ -376,6 +376,14 @@ fun ReadConfigScreen(
                         viewModel.onIntent(ReadConfigIntent.ShowReadTitleAdditionChanged(it))
                     }
                 )
+
+                SwitchSettingItem(
+                    title = stringResource(R.string.show_menu_icon),
+                    checked = state.showMenuIcon,
+                    onCheckedChange = {
+                        viewModel.onIntent(ReadConfigIntent.ShowMenuIconChanged(it))
+                    }
+                )
                 }
             }
         }

--- a/app/src/main/java/io/legado/app/ui/config/readConfig/ReadConfigViewModel.kt
+++ b/app/src/main/java/io/legado/app/ui/config/readConfig/ReadConfigViewModel.kt
@@ -203,6 +203,12 @@ class ReadConfigViewModel(
                     postEvent(EventBus.UPDATE_READ_ACTION_BAR, true)
                 }
 
+                is ReadConfigIntent.ShowMenuIconChanged -> {
+                    ReadConfig.showMenuIcon = intent.value
+                    readSettingsRepository.setShowMenuIcon(intent.value)
+                    postEvent(EventBus.UPDATE_READ_ACTION_BAR, true)
+                }
+
                 is ReadConfigIntent.PageKeysChanged -> {
                     readSettingsRepository.setPageKeys(intent.prevKeys, intent.nextKeys)
                 }
@@ -260,7 +266,8 @@ class ReadConfigViewModel(
             showReadTitleAddition = showReadTitleAddition,
             autoReadSpeed = autoReadSpeed,
             prevKeys = prevKeys,
-            nextKeys = nextKeys
+            nextKeys = nextKeys,
+            showMenuIcon = showMenuIcon
         )
     }
 }

--- a/app/src/main/java/io/legado/app/ui/config/readConfig/ReadMenuConfig.kt
+++ b/app/src/main/java/io/legado/app/ui/config/readConfig/ReadMenuConfig.kt
@@ -45,6 +45,11 @@ object ReadMenuConfig {
         true
     )
 
+    var showMenuIcon by prefDelegate(
+        PreferKey.showMenuIcon,
+        true
+    )
+
     // --- 点击区域配置 ---
 
     var clickActionTL by prefDelegate(

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1138,6 +1138,7 @@
     <string name="custom_welcome">自定义欢迎页</string>
     <string name="custom_welcome_summary">是否使用自定义欢迎页</string>
     <string name="show_icon">显示图标</string>
+    <string name="show_menu_icon">展示菜单项图标</string>
     <string name="show_default_book_icon">显示默认书籍图标</string>
     <string name="cache_export">书籍缓存</string>
     <string name="assists_key_config">辅助按键配置</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -906,6 +906,7 @@
     <string name="restore_ignore">Bypass List</string>
     <string name="restore_ignore_summary">Ignore some contents while restoring</string>
     <string name="read_config">Reading Interface Settings</string>
+    <string name="show_menu_icon">Show Menu Item Icons</string>
     <string name="read_config_global_theme">Global &amp; Theme</string>
     <string name="read_config_layout_spacing">Layout &amp; Spacing</string>
     <string name="read_config_text_effects">Text &amp; Effects</string>


### PR DESCRIPTION
新增“展示菜单项图标”配置开关 便于视觉快速锁定
更多设置与阅读配置界面支持切换该配置
右上角菜单根据配置动态显示或隐藏图标
<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/74d63514-5c28-4288-b4e7-f11845106928" />
