### PR TITLE
fix：阅读界面菜单滑动冲突的问题 #1500

### DIFF
--- a/app/src/main/java/io/legado/app/ui/book/read/sheet/ReadStyleSheet.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/sheet/ReadStyleSheet.kt
@@ -13,19 +13,27 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.layout.layout
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.unit.dp
 import io.legado.app.R
 import io.legado.app.ui.book.read.ConfigUpdate
@@ -34,6 +42,8 @@ import io.legado.app.ui.book.read.ReadBookIntent
 import io.legado.app.ui.book.read.ReadBookStyleConfig
 import io.legado.app.ui.widget.components.tabRow.CardTabRow
 import kotlinx.coroutines.launch
+
+private val SwipeThreshold = 300.dp
 
 @Composable
 fun ReadStyleContent(
@@ -54,6 +64,79 @@ fun ReadStyleContent(
     val scope = rememberCoroutineScope()
     val pagerState = rememberPagerState(pageCount = { 2 })
     var currentPage by remember { mutableIntStateOf(0) }
+    var systemMenuPage by remember { mutableIntStateOf(0) }
+    var parentUserScrollEnabled by remember { mutableStateOf(true) }
+    var lastActionTime by remember { mutableLongStateOf(0L) }
+    val currentOnOpenMoreConfig by rememberUpdatedState(onOpenMoreConfig)
+
+    val density = LocalDensity.current
+    var isAnimatingParent by remember { mutableStateOf(false) }
+    val nestedScrollConnection = remember(pagerState, density) {
+        object : NestedScrollConnection {
+            override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
+                if (isAnimatingParent) {
+                    return available
+                }
+                return Offset.Zero
+            }
+
+            override fun onPostScroll(
+                consumed: Offset,
+                available: Offset,
+                source: NestedScrollSource
+            ): Offset {
+                if (isAnimatingParent) {
+                    return available
+                }
+                return Offset.Zero
+            }
+
+            override suspend fun onPostFling(consumed: Velocity, available: Velocity): Velocity {
+                if (isAnimatingParent) {
+                    return available
+                }
+                return Velocity.Zero
+            }
+
+            override suspend fun onPreFling(available: Velocity): Velocity {
+                if (isAnimatingParent) {
+                    return available
+                }
+                val position = pagerState.currentPage + pagerState.currentPageOffsetFraction
+                //Log.d("fansangg", "onPreFling: available.x = ${available.x}, systemMenuPage = $systemMenuPage, parentPage = ${pagerState.currentPage}, parentOffset = ${pagerState.currentPageOffsetFraction}, position = $position")
+                if (systemMenuPage == 0 && pagerState.currentPage == 1 && position < 0.99f) {
+                    val thresholdPx = with(density) { SwipeThreshold.toPx() }
+                    val targetPage = if (available.x > thresholdPx || position < 0.8f) 0 else 1
+                    isAnimatingParent = true
+                    parentUserScrollEnabled = false
+                    scope.launch {
+                        try {
+                            pagerState.animateScrollToPage(
+                                page = targetPage,
+                                animationSpec = tween(durationMillis = 300, easing = FastOutSlowInEasing)
+                            )
+                        }  finally {
+                            isAnimatingParent = false
+                            parentUserScrollEnabled = true
+                        }
+                    }
+                    return available
+                }
+                if (systemMenuPage == 2 && pagerState.currentPage == 1) {
+                    val thresholdPx = with(density) { SwipeThreshold.toPx() }
+                    if (available.x < -thresholdPx) {
+                        val currentTime = System.currentTimeMillis()
+                        if (currentTime - lastActionTime > 800L) {
+                            lastActionTime = currentTime
+                            currentOnOpenMoreConfig()
+                        }
+                        return available
+                    }
+                }
+                return Velocity.Zero
+            }
+        }
+    }
 
     val pageHeights = remember { mutableStateMapOf<Int, Int>() }
     val animatedHeight by rememberPagerAnimatedHeight(pagerState, pageHeights)
@@ -72,6 +155,7 @@ fun ReadStyleContent(
         HorizontalPager(
             state = pagerState,
             verticalAlignment = Alignment.Top,
+            userScrollEnabled = parentUserScrollEnabled,
             modifier = Modifier
                 .weight(1f, fill = false)
                 .clipToBounds()
@@ -101,11 +185,20 @@ fun ReadStyleContent(
                         styleConfig = styleConfig,
                     )
 
-                    1 -> SystemMenuPage(
-                        customIcons = readMenuCustomIcons,
-                        bottomBarButtons = bottomBarButtons,
-                        onIntent = onIntent,
-                    )
+                    1 -> {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .nestedScroll(nestedScrollConnection)
+                        ) {
+                            SystemMenuPage(
+                                customIcons = readMenuCustomIcons,
+                                bottomBarButtons = bottomBarButtons,
+                                onIntent = onIntent,
+                                onPageChanged = { systemMenuPage = it }
+                            )
+                        }
+                    }
                 }
             }
         }

--- a/app/src/main/java/io/legado/app/ui/book/read/sheet/SystemMenuPage.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/sheet/SystemMenuPage.kt
@@ -4,14 +4,19 @@ import android.content.Context
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.List
@@ -26,14 +31,8 @@ import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.SkipNext
 import androidx.compose.material.icons.filled.SkipPrevious
 import androidx.compose.material.icons.filled.Translate
-import androidx.compose.foundation.background
-import androidx.compose.foundation.border
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateMapOf
@@ -49,12 +48,10 @@ import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.onSizeChanged
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringArrayResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import io.legado.app.R
@@ -71,13 +68,13 @@ import io.legado.app.ui.theme.LegadoTheme
 import io.legado.app.ui.widget.components.SectionTitle
 import io.legado.app.ui.widget.components.dialog.ColorPickerSheet
 import io.legado.app.ui.widget.components.settingItem.TinyClearColorModeSettingItem
-import io.legado.app.ui.widget.components.text.AppText
 import io.legado.app.ui.widget.components.settingItem.TinyClickableSettingItem
 import io.legado.app.ui.widget.components.settingItem.TinyColorModeSettingItem
 import io.legado.app.ui.widget.components.settingItem.TinyDropdownSettingItem
 import io.legado.app.ui.widget.components.settingItem.TinySliderSettingItem
 import io.legado.app.ui.widget.components.settingItem.TinySwitchSettingItem
 import io.legado.app.ui.widget.components.tabRow.CardTabRow
+import io.legado.app.ui.widget.components.text.AppText
 import io.legado.app.utils.GSON
 import io.legado.app.utils.fromJsonObject
 import kotlinx.coroutines.launch
@@ -99,8 +96,8 @@ internal fun SystemMenuPage(
     bottomBarButtons: List<ReadBookButtonConfigItem>,
     modifier: Modifier = Modifier,
     onIntent: (ReadBookIntent) -> Unit,
+    onPageChanged: (Int) -> Unit = {},
 ) {
-    val context = LocalContext.current
     val readSettingsRepository: ReadSettingsRepository = koinInject()
     val preferences by readSettingsRepository.preferences.collectAsStateWithLifecycle(
         initialValue = ReadPreferences()
@@ -124,6 +121,7 @@ internal fun SystemMenuPage(
             if (clickScrollCount == 0) {
                 selectedTab = page
             }
+            onPageChanged(page)
         }
     }
 


### PR DESCRIPTION
由于SystemMenuPage里也有HorizontalPager，导致在SystemMenuPage page0的时候，滑动回GlobalThemePage会比较困难，小幅度的滑动，fling被子pager消耗，导致父pager没有足够滑动偏移量，以及MutationInterruptedException这个异常导致卡在两页中间

现在是用了一个取巧的方案来解决，onPreFling内如果滑动距离大于300dp，则执行animateScrollToPage，顺便加了一个在SystemMenuPage，page == 2的时候继续滑，执行onOpenMoreConfig

Closes #1500 