### PR TITLE
fix：样式更新后，菜单内列未更新的问题

### DIFF
--- a/app/src/main/java/io/legado/app/ui/book/read/sheet/BgTextConfigSheet.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/sheet/BgTextConfigSheet.kt
@@ -111,6 +111,7 @@ fun BgTextConfigSheet(
                     title = stringResource(R.string.delete),
                     imageVector = Icons.Default.Delete,
                     modifier = Modifier.weight(1f),
+                    enabled = styleConfig.styleSelect >= 5,
                     onClick = { onIntent(ReadBookIntent.DeleteCurrentReadStyleConfig) },
                 )
                 ActionCard(
@@ -303,12 +304,14 @@ private fun ActionCard(
     title: String,
     imageVector: ImageVector,
     modifier: Modifier = Modifier,
+    enabled: Boolean = true,
     onClick: () -> Unit,
 ) {
+    val contentAlpha = if (enabled) 1f else 0.38f
     NormalCard(
-        onClick = onClick,
+        onClick = if (enabled) onClick else null,
         modifier = modifier,
-        containerColor = LegadoTheme.colorScheme.surfaceContainerLow,
+        containerColor = if (enabled) LegadoTheme.colorScheme.surfaceContainerLow else LegadoTheme.colorScheme.surfaceContainerLow.copy(alpha = 0.5f),
     ) {
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
@@ -320,14 +323,14 @@ private fun ActionCard(
             Icon(
                 imageVector = imageVector,
                 contentDescription = null,
-                tint = LegadoTheme.colorScheme.onSurfaceVariant,
+                tint = LegadoTheme.colorScheme.onSurfaceVariant.copy(alpha = contentAlpha),
                 modifier = Modifier.size(20.dp),
             )
             Spacer(Modifier.height(4.dp))
             Text(
                 text = title,
                 style = LegadoTheme.typography.labelSmall,
-                color = LegadoTheme.colorScheme.onSurfaceVariant,
+                color = LegadoTheme.colorScheme.onSurfaceVariant.copy(alpha = contentAlpha),
             )
         }
     }

--- a/app/src/main/java/io/legado/app/ui/book/read/sheet/GlobalThemePage.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/sheet/GlobalThemePage.kt
@@ -86,13 +86,19 @@ fun GlobalThemePage(
     val pageAnim = styleConfig.pageAnim
     val styleSelect = styleConfig.styleSelect
     val shareLayout = styleConfig.shareLayout
-    // configList needs to be read from ReadBookConfig since it's a list of Config objects
-    // We use styleConfig.configCount to detect when the list changes
-    var configList by remember { mutableStateOf(ReadBookConfig.configList.toList()) }
 
-    // Re-read configList when configCount changes (indicates list was modified)
-    LaunchedEffect(styleConfig.configCount) {
-        configList = ReadBookConfig.configList.toList()
+    val configList = remember(
+        styleConfig.configCount,
+        styleConfig.styleName,
+        styleConfig.bgAlpha,
+        styleConfig.bgType,
+        styleConfig.bgStr,
+        styleConfig.textColor,
+        styleConfig.bgTypeNight,
+        styleConfig.bgStrNight,
+        styleConfig.textColorNight,
+    ) {
+        ReadBookConfig.configList.map { it.copy() }
     }
 
     Column(


### PR DESCRIPTION
1. 样式更新背景图、修改名称后，GlobalThemePage的item没有更新
2. BgTextConfigSheet点击删除，没有卵用，看了一下发现0-4是不让删的，但是也没有反馈，加了一个disable的样式
https://github.com/HapeLee/legado-with-MD3/blob/ad8b8df13f7fe49cb66d7e85b7959a6ec78c9c2e/app/src/main/java/io/legado/app/help/config/ReadBookConfig.kt#L165-L178
