### PR TITLE
[codex] 按醒目标签规则排序书籍详情标签

### DIFF
--- a/app/src/main/java/io/legado/app/help/book/BookExtensions.kt
+++ b/app/src/main/java/io/legado/app/help/book/BookExtensions.kt
@@ -355,7 +355,7 @@ fun parseHighlightedTags(
         return emptyList<HighlightedTag>() to kindLabels
     }
 
-    val compiledRules = rules.mapNotNull { rule ->
+    val compiledRules = rules.sortedBy { it.order }.mapNotNull { rule ->
         val regex = try {
             Regex(rule.pattern)
         } catch (_: Exception) {
@@ -367,8 +367,7 @@ fun parseHighlightedTags(
         return emptyList<HighlightedTag>() to kindLabels
     }
 
-    // Group matched labels by rule
-    val ruleToLabels = linkedMapOf<HighlightTagRule, MutableList<String>>()
+    val ruleToLabels = mutableMapOf<HighlightTagRule, MutableList<String>>()
     val regular = mutableListOf<String>()
 
     for (tag in kindLabels) {
@@ -385,11 +384,13 @@ fun parseHighlightedTags(
         }
     }
 
-    val highlighted = ruleToLabels.map { (rule, labels) ->
-        HighlightedTag(
-            matchedLabels = labels,
-            title = rule.title.takeIf { it.isNotBlank() },
-        )
+    val highlighted = compiledRules.mapNotNull { (rule, _) ->
+        ruleToLabels[rule]?.let { labels ->
+            HighlightedTag(
+                matchedLabels = labels,
+                title = rule.title.takeIf { it.isNotBlank() },
+            )
+        }
     }
 
     return highlighted to regular

--- a/app/src/test/java/io/legado/app/help/book/BookExtensionsTest.kt
+++ b/app/src/test/java/io/legado/app/help/book/BookExtensionsTest.kt
@@ -1,0 +1,35 @@
+package io.legado.app.help.book
+
+import io.legado.app.data.entities.HighlightTagRule
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class BookExtensionsTest {
+
+    @Test
+    fun parseHighlightedTags_ordersMatchesByRuleOrder() {
+        val rules = listOf(
+            HighlightTagRule(
+                id = 2,
+                title = "次要",
+                pattern = "动作",
+                order = 1,
+            ),
+            HighlightTagRule(
+                id = 1,
+                title = "优先",
+                pattern = "奇幻",
+                order = 0,
+            ),
+        )
+
+        val (highlighted, regular) = parseHighlightedTags(
+            kindLabels = listOf("动作", "普通", "奇幻"),
+            rules = rules,
+        )
+
+        assertEquals(listOf("优先", "次要"), highlighted.map { it.title })
+        assertEquals(listOf(listOf("奇幻"), listOf("动作")), highlighted.map { it.matchedLabels })
+        assertEquals(listOf("普通"), regular)
+    }
+}


### PR DESCRIPTION
## 变更内容

- 书籍详情页解析醒目标签时，先按醒目标签规则的 `order` 排序
- 最终展示结果按规则顺序组装，不再取决于书籍标签的先后顺序
- 保留同一醒目标签内已匹配书籍标签的原有顺序
- 新增书籍标签顺序与规则顺序相反的回归测试

## 原因

DAO 虽然已经按 `order` 返回醒目标签规则，但解析逻辑使用书籍标签首次命中的顺序构建结果，导致详情页展示顺序被书籍标签顺序覆盖。

## 影响

在醒目标签管理页拖动并保存顺序后，书籍详情页会按该顺序展示醒目标签。普通未匹配标签的顺序不变。

## 验证

- `./gradlew.bat :app:compileAppDebugKotlin`：通过
- 定向单测任务受仓库现有 `ClickActionConfigDialogTest` 缺少 Robolectric 依赖影响，测试源码编译阶段被阻断；本次新增测试未报告编译错误