### PR TITLE
fix：阅读界面切换深浅色后，排版问题

### DIFF
--- a/app/src/main/java/io/legado/app/help/config/ReadBookConfig.kt
+++ b/app/src/main/java/io/legado/app/help/config/ReadBookConfig.kt
@@ -36,6 +36,8 @@ import kotlin.reflect.KProperty
 @Suppress("ConstPropertyName")
 @Keep
 object ReadBookConfig {
+    var lastNavigationBarHeight: Int = 0
+
     private val readStyleRepository: ReadStyleRepository
         get() = GlobalContext.get().get()
 

--- a/app/src/main/java/io/legado/app/ui/book/read/page/PageView.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/page/PageView.kt
@@ -26,13 +26,14 @@ import io.legado.app.ui.book.read.page.entities.TextPos
 import io.legado.app.ui.book.read.page.provider.ChapterProvider
 import io.legado.app.ui.config.readConfig.ReadConfig
 import io.legado.app.ui.widget.BatteryView
+import androidx.core.view.updateLayoutParams
 import io.legado.app.utils.activity
-import io.legado.app.utils.applyNavigationBarPadding
 import io.legado.app.utils.applyStatusBarPadding
 import io.legado.app.utils.canvasrecorder.CanvasRecorder
 import io.legado.app.utils.dpToPx
 import io.legado.app.utils.gone
 import io.legado.app.utils.isContentScheme
+import io.legado.app.utils.navigationBarHeight
 import io.legado.app.utils.setOnApplyWindowInsetsListenerCompat
 import io.legado.app.utils.statusBarHeight
 import splitties.views.backgroundColor
@@ -87,7 +88,21 @@ class PageView(
         callBack?.let { binding.contentTextView.setCallBack(it) }
         upStyle()
         binding.vwStatusBar.applyStatusBarPadding()
-        binding.vwNavigationBar.applyNavigationBarPadding()
+        if (ReadBookConfig.lastNavigationBarHeight > 0) {
+            binding.vwNavigationBar.updateLayoutParams {
+                height = ReadBookConfig.lastNavigationBarHeight
+            }
+        }
+        binding.vwNavigationBar.setOnApplyWindowInsetsListenerCompat { v, windowInsets ->
+            val navHeight = windowInsets.navigationBarHeight
+            if (navHeight > 0) {
+                ReadBookConfig.lastNavigationBarHeight = navHeight
+            }
+            v.updateLayoutParams {
+                height = navHeight
+            }
+            windowInsets
+        }
     }
 
     override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {


### PR DESCRIPTION
阅读界面未隐藏导航栏的时候，切换深色和浅色模式时，排版会变，导致进度的slider也跳

https://github.com/user-attachments/assets/a640ee5d-33ff-426c-a98a-595f20050a87


<img width="1749" height="1027" alt="ScreenShot_2026-06-28_024730_676" src="https://github.com/user-attachments/assets/e848c0ee-850e-43f7-92bb-fcf76ae7ebd9" />

在Log上可以看出，切换后ReadView重建，会先进行measure，然后windowInsets的回调才拿到了导航栏的高度设置padding给vwNavigationBar，所以会导致vwNavigationBar的高度一直是0，然后ContentTextView拿到了一个错误的高度，因为高度变了，所以ChapterProvider走了upLayout。

--- 

我把导航栏的高度存了一份，在PageView init的时候直接把上次导航栏高度设进去，防止onMeasure比windowInsets的回调更早，然后在回调里也给vwNavigationBar设置了高度，因为设置padding不会重新requestLayout