### PR TITLE
fix：三星Spen失效的问题，并添加上一章和下一章的操作选项

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -44,7 +44,12 @@
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
+                <action android:name="com.samsung.android.support.REMOTE_ACTION" />
             </intent-filter>
+
+            <meta-data
+                android:name="com.samsung.android.support.REMOTE_ACTION"
+                android:resource="@xml/spen_remote_actions" />
         </activity>
         <activity
             android:name=".ui.main.Launcher0"
@@ -54,7 +59,12 @@
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
+                <action android:name="com.samsung.android.support.REMOTE_ACTION" />
             </intent-filter>
+
+            <meta-data
+                android:name="com.samsung.android.support.REMOTE_ACTION"
+                android:resource="@xml/spen_remote_actions" />
         </activity>
         <!-- 图标1 -->
         <activity
@@ -65,7 +75,12 @@
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
+                <action android:name="com.samsung.android.support.REMOTE_ACTION" />
             </intent-filter>
+
+            <meta-data
+                android:name="com.samsung.android.support.REMOTE_ACTION"
+                android:resource="@xml/spen_remote_actions" />
         </activity>
         <!-- 图标2 -->
         <activity
@@ -76,7 +91,12 @@
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
+                <action android:name="com.samsung.android.support.REMOTE_ACTION" />
             </intent-filter>
+
+            <meta-data
+                android:name="com.samsung.android.support.REMOTE_ACTION"
+                android:resource="@xml/spen_remote_actions" />
         </activity>
         <!-- 图标3 -->
         <activity
@@ -87,7 +107,12 @@
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
+                <action android:name="com.samsung.android.support.REMOTE_ACTION" />
             </intent-filter>
+
+            <meta-data
+                android:name="com.samsung.android.support.REMOTE_ACTION"
+                android:resource="@xml/spen_remote_actions" />
         </activity>
         <!-- 图标4 -->
         <activity
@@ -98,7 +123,12 @@
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
+                <action android:name="com.samsung.android.support.REMOTE_ACTION" />
             </intent-filter>
+
+            <meta-data
+                android:name="com.samsung.android.support.REMOTE_ACTION"
+                android:resource="@xml/spen_remote_actions" />
         </activity>
         <!-- 图标5 -->
         <activity
@@ -109,7 +139,12 @@
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
+                <action android:name="com.samsung.android.support.REMOTE_ACTION" />
             </intent-filter>
+
+            <meta-data
+                android:name="com.samsung.android.support.REMOTE_ACTION"
+                android:resource="@xml/spen_remote_actions" />
         </activity>
         <!-- 图标6 -->
         <activity
@@ -120,7 +155,12 @@
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
+                <action android:name="com.samsung.android.support.REMOTE_ACTION" />
             </intent-filter>
+
+            <meta-data
+                android:name="com.samsung.android.support.REMOTE_ACTION"
+                android:resource="@xml/spen_remote_actions" />
         </activity>
         <!-- 主界面 -->
         <activity
@@ -132,7 +172,12 @@
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
+                <action android:name="com.samsung.android.support.REMOTE_ACTION" />
             </intent-filter>
+
+            <meta-data
+                android:name="com.samsung.android.support.REMOTE_ACTION"
+                android:resource="@xml/spen_remote_actions" />
         </activity>
         <activity
             android:name=".ui.welcome.WelcomeActivity"

--- a/app/src/main/java/io/legado/app/ui/book/read/ReadBookController.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/ReadBookController.kt
@@ -975,6 +975,20 @@ class ReadBookController(
                 handleKeyPage(PageDirection.NEXT, longPress)
                 return true
             }
+
+            KeyEvent.KEYCODE_MEDIA_NEXT -> {
+                if (ReadBook.book != null) {
+                    ReadBook.moveToNextChapter(true)
+                }
+                return true
+            }
+
+            KeyEvent.KEYCODE_MEDIA_PREVIOUS -> {
+                if (ReadBook.book != null) {
+                    ReadBook.moveToPrevChapter(upContent = true, toLast = false)
+                }
+                return true
+            }
         }
         return false
     }

--- a/app/src/main/res/xml/spen_remote_actions.xml
+++ b/app/src/main/res/xml/spen_remote_actions.xml
@@ -11,6 +11,7 @@
         trigger_key="PAGE_DOWN">
         <preference name="gesture" value="click" />
     </action>
+
     <action
         id="prev_page"
         label="@string/prev_page"
@@ -19,5 +20,23 @@
         repeatable_interval="short"
         trigger_key="PAGE_UP">
         <preference name="gesture" value="double_click" />
+    </action>
+
+    <action
+        id="prev_chapter"
+        label="@string/previous_chapter"
+        priority="3"
+        repeatable="false"
+        trigger_key="MEDIA_PREVIOUS">
+        <preference name="gesture" value="move_left" />
+    </action>
+
+    <action
+        id="next_chapter"
+        label="@string/next_chapter"
+        priority="4"
+        repeatable="false"
+        trigger_key="MEDIA_NEXT">
+        <preference name="gesture" value="move_right" />
     </action>
 </remote-actions>


### PR DESCRIPTION
在xml是有spen_remote_actions，看了一下manifest的修改记录

<img width="1829" height="603" alt="QC_Screenshot_1782621492961" src="https://github.com/user-attachments/assets/445ad23c-e4d4-4c8b-8154-0003df1bba72" />

之前迁移的时候，com.samsung.android.support.REMOTE_ACTION被漏掉了，导致在mainactivity无法识别spen的操作。

---

然后添加了两个操作选项，上一章和下一章。

<img width="1440" height="3088" alt="Screenshot_20260628_123213" src="https://github.com/user-attachments/assets/371903fe-04c8-428d-b6b6-feb2852c324d" />


https://github.com/user-attachments/assets/47f38e26-4caa-4f73-9c66-7552fc174ab9


