### PR TITLE
fix:阅读界面软键盘弹起后导致重新排版的问题

### DIFF
--- a/app/src/main/java/io/legado/app/ui/book/read/page/PageView.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/page/PageView.kt
@@ -94,6 +94,11 @@ class PageView(
             }
         }
         binding.vwNavigationBar.setOnApplyWindowInsetsListenerCompat { v, windowInsets ->
+            val isImeVisible = windowInsets.isVisible(WindowInsetsCompat.Type.ime())
+            if (isImeVisible) {
+                return@setOnApplyWindowInsetsListenerCompat windowInsets
+            }
+            //Log.d("fansangg", "vwNavigationBar OnApplyWindowInsetsListener: navHeight=$navHeight, isImeVisible=${windowInsets.isVisible(WindowInsetsCompat.Type.ime())}, imeHeight=${windowInsets.getInsets(WindowInsetsCompat.Type.ime()).bottom}, systemBarsHeight=${windowInsets.getInsets(WindowInsetsCompat.Type.systemBars()).bottom}")
             val navHeight = windowInsets.navigationBarHeight
             if (navHeight > 0) {
                 ReadBookConfig.lastNavigationBarHeight = navHeight


### PR DESCRIPTION
<img width="1592" height="421" alt="ScreenShot_2026-07-01_183730_576" src="https://github.com/user-attachments/assets/78154c0e-bf47-40e6-a3c4-dc3aa652579c" />

软键盘弹起后，navHeight会变成0，导致高度变化走了upLayout
