### PR TITLE
fix:一些UI问题修复

### DIFF
--- a/app/src/main/java/io/legado/app/ui/book/read/ReadBookMenuBar.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/ReadBookMenuBar.kt
@@ -688,6 +688,7 @@ private fun ReadBookMenuSurface(
                             title = stringResource(R.string.header_footer),
                             maxHeight = maxHeight,
                             scrollContent = false,
+                            animateSize = false,
                             bottomPadding = if (extendSurfaceToNavigationBar) navBarHeight else 0.dp,
                             onBack = { onIntent(ReadBookIntent.ReadMenuBack) },
                         ) {
@@ -2367,23 +2368,27 @@ private fun MenuBottomBar(
             ) {
                 pageButtons.chunked(itemsPerRow).forEach { rowButtons ->
                     Row(
-                        horizontalArrangement = when {
-                            rowButtons.size > 1 -> Arrangement.SpaceBetween
-                            else -> Arrangement.spacedBy(32.dp, Alignment.CenterHorizontally)
-                        },
-                        modifier = Modifier
-                            .fillMaxWidth(),
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically
                     ) {
                         rowButtons.forEach { button ->
-                            ToolButtonItem(
-                                button = button,
-                                state = state,
-                                colors = colors,
-                                backdrop = backdrop,
-                                glassEnabled = buttonGlassEnabled,
-                                labelColor = labelColor,
-                                modifier = Modifier.width(if (buttonGlassEnabled) 48.dp else 40.dp),
-                            )
+                            Box(
+                                modifier = Modifier.weight(1f),
+                                contentAlignment = Alignment.Center
+                            ) {
+                                ToolButtonItem(
+                                    button = button,
+                                    state = state,
+                                    colors = colors,
+                                    backdrop = backdrop,
+                                    glassEnabled = buttonGlassEnabled,
+                                    labelColor = labelColor,
+                                    modifier = Modifier.width(if (buttonGlassEnabled) 48.dp else 40.dp),
+                                )
+                            }
+                        }
+                        repeat(itemsPerRow - rowButtons.size) {
+                            Spacer(modifier = Modifier.weight(1f))
                         }
                     }
                 }

--- a/app/src/main/java/io/legado/app/ui/book/read/sheet/HeaderFooterPage.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/sheet/HeaderFooterPage.kt
@@ -10,9 +10,7 @@ import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.pager.HorizontalPager
@@ -24,8 +22,6 @@ import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.filled.TextFields
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -45,7 +41,6 @@ import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringArrayResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -315,7 +310,7 @@ internal fun HeaderFooterPage(
                                 showColorPicker = true
                             },
                         )
-                        Spacer(Modifier.height(8.dp))
+
                         TinyClickableSettingItem(
                             title = stringResource(R.string.padding),
                             description = stringResource(
@@ -445,7 +440,7 @@ internal fun HeaderFooterPage(
                                 showColorPicker = true
                             },
                         )
-                        Spacer(Modifier.height(8.dp))
+
                         TinyClickableSettingItem(
                             title = stringResource(R.string.padding),
                             description = stringResource(

--- a/app/src/main/java/io/legado/app/ui/book/read/sheet/SystemMenuPage.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/sheet/SystemMenuPage.kt
@@ -9,9 +9,7 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.pager.HorizontalPager
@@ -400,8 +398,6 @@ private fun GlobalMenuTab(
             },
         )
 
-        Spacer(Modifier.height(8.dp))
-
         SectionTitle(stringResource(R.string.show_brightness_view))
 
         TinyDropdownSettingItem(
@@ -424,8 +420,6 @@ private fun GlobalMenuTab(
                 },
             )
         }
-
-        Spacer(Modifier.height(8.dp))
 
         val borderEnabled = preferences.readMenuBorderWidth > 0
         TinySwitchSettingItem(
@@ -466,8 +460,6 @@ private fun GlobalMenuTab(
                 )
             }
         }
-
-        Spacer(Modifier.height(8.dp))
 
         TinySliderSettingItem(
             title = stringResource(R.string.read_menu_blur_radius),
@@ -730,7 +722,7 @@ private fun TopBarTab(
                 onIntent(ReadBookIntent.ShowSheet(ReadBookSheet.TitleBarIconConfig))
             },
         )
-        Spacer(Modifier.height(8.dp))
+
         TinySwitchSettingItem(
             title = stringResource(R.string.read_menu_bar_blur),
             checked = topBarBlurEnabled,

--- a/app/src/main/java/io/legado/app/ui/widget/components/AppFloatingActionButton.kt
+++ b/app/src/main/java/io/legado/app/ui/widget/components/AppFloatingActionButton.kt
@@ -7,6 +7,7 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.scaleIn
 import androidx.compose.animation.scaleOut
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -94,20 +95,26 @@ fun AppFloatingActionButton(
         )
     } else {
         if (tooltipText != null) {
-            TooltipBox(
-                positionProvider = TooltipDefaults.rememberTooltipPositionProvider(
-                    TooltipAnchorPosition.Above
-                ),
-                tooltip = { PlainTooltip { AppText(tooltipText) } },
-                state = rememberTooltipState(),
-            ) {
-                FloatingActionButton(
-                    onClick = onClick,
-                    modifier = modifier,
-                    containerColor = containerColor,
-                    contentColor = contentColor,
-                    content = fabContent
-                )
+            Box(modifier = modifier) {
+                TooltipBox(
+                    positionProvider = TooltipDefaults.rememberTooltipPositionProvider(
+                        TooltipAnchorPosition.Above
+                    ),
+                    tooltip = {
+                        PlainTooltip(
+                            containerColor = LegadoTheme.colorScheme.surfaceContainerLow,
+                            contentColor = LegadoTheme.colorScheme.onSurface,
+                        ) { AppText(tooltipText) }
+                    },
+                    state = rememberTooltipState(),
+                ) {
+                    FloatingActionButton(
+                        onClick = onClick,
+                        containerColor = containerColor,
+                        contentColor = contentColor,
+                        content = fabContent
+                    )
+                }
             }
         } else {
             FloatingActionButton(


### PR DESCRIPTION
- AppFloatingActionButton 在tooltipText不为null的时候按钮位置不对

<img width="423" height="520" alt="QC_Screenshot_1783241800608" src="https://github.com/user-attachments/assets/a0fed726-f34a-4c7b-a7ad-eb11148bb55c" />

- 阅读菜单底部按钮排版问题

<img width="431" height="235" alt="QC_Screenshot_1783241864918" src="https://github.com/user-attachments/assets/8583a5fb-d1f9-4b9f-bffc-29bf9b5f2665" />

- 阅读设置菜单里一些冗余的间距

<img width="331" height="503" alt="QC_Screenshot_1783241918161" src="https://github.com/user-attachments/assets/a9d54c5e-be0a-4034-ad47-8782ab107583" />
