### PR TITLE
Fixes #1720。修复开启“自定义导出”时，TXT 格式被错误导出为 EPUB 的问题

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -173,6 +173,7 @@ dependencies {
     "baselineProfile"(project(":baselineprofile"))
     coreLibraryDesugaring(libs.desugar)
     testImplementation(libs.junit)
+    testImplementation(libs.robolectric)
     androidTestImplementation(libs.bundles.androidTest)
     implementation(libs.kotlin.stdlib)
     implementation(libs.kotlinx.collections.immutable)

--- a/app/src/main/java/io/legado/app/ui/book/manage/BookshelfManageScreen.kt
+++ b/app/src/main/java/io/legado/app/ui/book/manage/BookshelfManageScreen.kt
@@ -295,7 +295,7 @@ private fun BookshelfManageScreen(
         }
         val bookUrl = pendingExportBookUrl ?: return@rememberLauncherForActivityResult
         val book = booksByUrl[bookUrl] ?: return@rememberLauncherForActivityResult
-        if (state.exportConfig.enableCustomExport) {
+        if (state.exportConfig.isCustomEpubExportEnabled) {
             customExportPath = dirPath
             customExportBook = book
             customExportAllChapter = false
@@ -336,7 +336,7 @@ private fun BookshelfManageScreen(
         val path = ACache.get().getAsString(exportBookPathKey)
         if (path.isNullOrEmpty() || !FileDoc.fromDir(path).checkWrite()) {
             selectExportFolder(book.bookUrl)
-        } else if (state.exportConfig.enableCustomExport) {
+        } else if (state.exportConfig.isCustomEpubExportEnabled) {
             customExportPath = path
             customExportBook = book
             customExportAllChapter = false

--- a/app/src/main/java/io/legado/app/ui/book/manage/BookshelfManageScreenViewModel.kt
+++ b/app/src/main/java/io/legado/app/ui/book/manage/BookshelfManageScreenViewModel.kt
@@ -60,7 +60,10 @@ data class BookshelfManageScreenExportConfig(
     val exportCharset: String = "UTF-8",
     val bookExportFileName: String? = null,
     val episodeExportFileName: String = ""
-)
+) {
+    val isCustomEpubExportEnabled: Boolean
+        get() = enableCustomExport && exportType == 1
+}
 
 data class BookshelfManageScreenUiState(
     val groupId: Long = -1,

--- a/app/src/test/java/io/legado/app/ui/book/manage/BookshelfManageScreenExportConfigTest.kt
+++ b/app/src/test/java/io/legado/app/ui/book/manage/BookshelfManageScreenExportConfigTest.kt
@@ -1,0 +1,30 @@
+package io.legado.app.ui.book.manage
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class BookshelfManageScreenExportConfigTest {
+
+    @Test
+    fun customExport_requiresEpubFormat() {
+        assertFalse(
+            BookshelfManageScreenExportConfig(
+                enableCustomExport = true,
+                exportType = 0
+            ).isCustomEpubExportEnabled
+        )
+        assertTrue(
+            BookshelfManageScreenExportConfig(
+                enableCustomExport = true,
+                exportType = 1
+            ).isCustomEpubExportEnabled
+        )
+        assertFalse(
+            BookshelfManageScreenExportConfig(
+                enableCustomExport = false,
+                exportType = 1
+            ).isCustomEpubExportEnabled
+        )
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -61,6 +61,7 @@ preference = "1.2.1"
 protobufJavalite = "4.26.1"
 quickChineseTransfer = "0.2.17"
 room = "2.8.4"
+robolectric = "4.16.1"
 splitties = "3.0.0"
 rhino = "1.8.1"
 desugar = "2.1.5"
@@ -187,6 +188,7 @@ room-compiler = { module = "androidx.room:room-compiler", version.ref = "room" }
 room-ktx = { module = "androidx.room:room-ktx", version.ref = "room" }
 room-runtime = { module = "androidx.room:room-runtime", version.ref = "room" }
 room-testing = { module = "androidx.room:room-testing", version.ref = "room" }
+robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 
 glide-glide = { module = "com.github.bumptech.glide:glide", version.ref = "glide" }
 glide-okhttp= { module = "com.github.bumptech.glide:okhttp3-integration", version.ref ="glide" }


### PR DESCRIPTION
自定义导出对话框包含章节范围、分卷数量和分卷文件名规则，底层无论选择“全部”还是指定章节，都会固定提交EPUB 导出。旧版的判断是“自定义导出开关开启，并且导出格式为 EPUB”才进入这条流程；Compose 迁移后遗漏了格式条件，导致
  TXT 被错误地引向 EPUB。
现在导出优先级恢复为格式优先：
选择 TXT 时，即便保留“自定义导出”开关，单本导出也直接按 TXT 执行。
选择 EPUB 且开启“自定义导出”时，才显示章节范围和分卷配置，并导出 EPUB。
开关状态仍会保留，用户切回 EPUB 后可继续使用自定义 EPUB 导出，不会意外修改既有偏好。
我将该规则集中为导出配置的明确条件，并
  同时覆盖了“开关开启但格式为 TXT”“开关开启且格式为 EPUB”“开关关闭但格式为EPUB”三个组合，防止相同优先级错误再次出现。