### PR TITLE
fix(search): 修复全文搜索清空文本退出后再次进入仍残留单字的Bug

### DIFF
--- a/app/src/main/java/io/legado/app/data/repository/SearchContentRepository.kt
+++ b/app/src/main/java/io/legado/app/data/repository/SearchContentRepository.kt
@@ -31,8 +31,18 @@ class SearchContentRepository {
         val results: List<SearchResult>,
     )
 
+    @Synchronized
     fun getLastSession(bookUrl: String): SearchSession? {
         return lastSearchSession?.takeIf { it.bookUrl == bookUrl }
+    }
+
+    @Synchronized
+    fun clearSession(bookUrl: String) {
+        if (lastSearchSession?.bookUrl == bookUrl) {
+            lastSearchSession = null
+            lastSearchResults = null
+            lastQueryKey = null
+        }
     }
 
     fun beginSearch(
@@ -44,6 +54,7 @@ class SearchContentRepository {
         cacheResults(bookUrl, query, replaceEnabled, regexReplace, emptyList())
     }
 
+    @Synchronized
     fun getCache(
         bookUrl: String,
         query: String,
@@ -93,6 +104,7 @@ class SearchContentRepository {
         emit(ArrayList(allResults))
     }.flowOn(Dispatchers.Default)
 
+    @Synchronized
     private fun cacheResults(
         bookUrl: String,
         query: String,

--- a/app/src/main/java/io/legado/app/ui/book/searchContent/SearchContentViewModel.kt
+++ b/app/src/main/java/io/legado/app/ui/book/searchContent/SearchContentViewModel.kt
@@ -134,6 +134,7 @@ class SearchContentViewModel(
         val regex = _regexReplace.value
 
         if (query.isBlank()) {
+            searchContentRepository.clearSession(bookUrl)
             _uiState.update {
                 it.copy(
                     isSearching = false,


### PR DESCRIPTION
- 在 SearchContentRepository 中新增 `clearSession` 用于清理特定书籍的搜索历史会话缓存
- 在 SearchContentViewModel.executeSearch 检测到搜索词被清空时，主动调用 `clearSession` 清除旧的会话，避免下次重新进入时恢复旧缓存中退格残留的单个字符
Closes #1733