### PR TITLE
新增启动时自动检查更新功能

### DIFF
--- a/.github/scripts/publish-update-manifest.sh
+++ b/.github/scripts/publish-update-manifest.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+channel="${1:-}"
+version="${2:-}"
+
+if [[ "$channel" != "official" && "$channel" != "beta" ]]; then
+  echo "Unsupported update channel: $channel" >&2
+  exit 1
+fi
+if [[ -z "$version" ]]; then
+  echo "Release version is required" >&2
+  exit 1
+fi
+: "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+: "${RUNNER_TEMP:?RUNNER_TEMP is required}"
+
+manifest_branch="update-manifests"
+manifest_dir="$RUNNER_TEMP/$manifest_branch"
+release_tmp="$manifest_dir/release.tmp"
+release_list_tmp="$manifest_dir/releases.tmp"
+
+write_manifest() {
+  local source_file="$1"
+  local target_channel="$2"
+  local expected_version="$3"
+  local target_file="$manifest_dir/$target_channel.json"
+  local target_tmp="$target_file.tmp"
+  local expected_prerelease="false"
+  if [[ "$target_channel" == "beta" ]]; then
+    expected_prerelease="true"
+  fi
+
+  jq -e \
+    --arg version "$expected_version" \
+    --argjson prerelease "$expected_prerelease" \
+    'if .tag_name == $version and .prerelease == $prerelease and (.assets | type == "array") then
+      {
+        tag_name,
+        name,
+        body: (.body // ""),
+        prerelease,
+        created_at,
+        assets: [.assets[] | {
+          browser_download_url,
+          content_type,
+          created_at,
+          download_count: 0,
+          id,
+          name,
+          state,
+          url
+        }]
+      }
+    else
+      error("Release response does not match the requested channel and version")
+    end' \
+    "$source_file" > "$target_tmp"
+  mv "$target_tmp" "$target_file"
+}
+
+rm -rf "$manifest_dir"
+if git fetch --no-tags origin "$manifest_branch"; then
+  git worktree add --detach "$manifest_dir" FETCH_HEAD
+else
+  git worktree add --detach "$manifest_dir" HEAD
+  git -C "$manifest_dir" checkout --orphan "$manifest_branch"
+  git -C "$manifest_dir" rm -q -rf --ignore-unmatch .
+fi
+trap 'git worktree remove --force "$manifest_dir" >/dev/null 2>&1 || true' EXIT
+
+gh api \
+  -H "Accept: application/vnd.github+json" \
+  -H "X-GitHub-Api-Version: 2026-03-10" \
+  "repos/$GITHUB_REPOSITORY/releases/tags/$version" > "$release_tmp"
+write_manifest "$release_tmp" "$channel" "$version"
+
+other_channel="official"
+if [[ "$channel" == "official" ]]; then
+  other_channel="beta"
+fi
+
+if [[ ! -f "$manifest_dir/$other_channel.json" ]]; then
+  if [[ "$other_channel" == "official" ]]; then
+    gh api \
+      -H "Accept: application/vnd.github+json" \
+      -H "X-GitHub-Api-Version: 2026-03-10" \
+      "repos/$GITHUB_REPOSITORY/releases/latest" > "$release_tmp"
+    other_version="$(jq -r '.tag_name' "$release_tmp")"
+    write_manifest "$release_tmp" "$other_channel" "$other_version"
+  else
+    gh api \
+      -H "Accept: application/vnd.github+json" \
+      -H "X-GitHub-Api-Version: 2026-03-10" \
+      "repos/$GITHUB_REPOSITORY/releases?per_page=100" > "$release_list_tmp"
+    if jq -e \
+      '[.[] | select(.draft == false and .prerelease == true)] | max_by(.created_at) | select(. != null)' \
+      "$release_list_tmp" > "$release_tmp"; then
+      other_version="$(jq -r '.tag_name' "$release_tmp")"
+      write_manifest "$release_tmp" "$other_channel" "$other_version"
+    fi
+  fi
+fi
+rm -f "$release_tmp" "$release_list_tmp"
+
+git -C "$manifest_dir" config user.name "github-actions[bot]"
+git -C "$manifest_dir" config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+git -C "$manifest_dir" add --all
+
+if git -C "$manifest_dir" diff --cached --quiet; then
+  echo "$channel update manifest is already current"
+  exit 0
+fi
+
+git -C "$manifest_dir" commit -m "Update release manifests for $version"
+git -C "$manifest_dir" push origin "HEAD:refs/heads/$manifest_branch"

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -383,6 +383,19 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: 发布静态更新清单
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.prepare.outputs.versionL }}
+          IS_RELEASE: ${{ needs.prepare.outputs.is_release }}
+        run: |
+          if [[ "$IS_RELEASE" == "true" ]]; then
+            CHANNEL="official"
+          else
+            CHANNEL="beta"
+          fi
+          bash .github/scripts/publish-update-manifest.sh "$CHANNEL" "$VERSION"
+
       - name: 发布到 Telegram 频道
         env:
           TG_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}

--- a/app/src/main/java/io/legado/app/constant/PreferKey.kt
+++ b/app/src/main/java/io/legado/app/constant/PreferKey.kt
@@ -178,6 +178,7 @@ object PreferKey {
     const val recordHeapDump = "recordHeapDump"
     const val optimizeRender = "optimizeRender"
     const val updateToVariant = "updateToVariant"
+    const val autoCheckUpdateOnStart = "autoCheckUpdateOnStart"
     const val streamReadAloudAudio = "streamReadAloudAudio"
     const val pauseReadAloudWhilePhoneCalls = "pauseReadAloudWhilePhoneCalls"
     const val readAloudByMediaButton = "readAloudByMediaButton"

--- a/app/src/main/java/io/legado/app/help/update/AppReleaseInfo.kt
+++ b/app/src/main/java/io/legado/app/help/update/AppReleaseInfo.kt
@@ -27,7 +27,7 @@ enum class AppVariant {
 @Keep
 data class GithubRelease(
     val assets: List<Asset>?,
-    val body: String,
+    val body: String?,
     @SerializedName("prerelease")
     val isPreRelease: Boolean,
     @SerializedName("tag_name")
@@ -43,14 +43,15 @@ data class GithubRelease(
 
         val version = tagName
         return selectCompatibleAssets(assets, supportedAbis)
-            .map { it.assetToAppReleaseInfo(isPreRelease, body, version) }
+            .map { it.assetToAppReleaseInfo(isPreRelease, body.orEmpty(), version) }
     }
 }
 
-private val releaseAbiSuffixes = listOf(
+private val releaseAbis = listOf(
     "arm64-v8a",
     "armeabi-v7a",
     "x86_64",
+    "armeabi",
     "x86"
 )
 
@@ -62,17 +63,16 @@ internal fun selectCompatibleAssets(
 
     supportedAbis.forEach { supportedAbi ->
         val matchingAssets = validAssets.filter { asset ->
-            asset.name.contains(supportedAbi, ignoreCase = true)
+            asset.releaseAbi.equals(supportedAbi, ignoreCase = true)
         }
         if (matchingAssets.isNotEmpty()) return matchingAssets
     }
 
-    return validAssets.filter { asset ->
-        releaseAbiSuffixes.none { abiSuffix ->
-            asset.name.contains(abiSuffix, ignoreCase = true)
-        }
-    }
+    return validAssets.filter { it.releaseAbi == null }
 }
+
+private val Asset.releaseAbi: String?
+    get() = releaseAbis.firstOrNull { name.contains(it, ignoreCase = true) }
 
 @Keep
 data class Asset(

--- a/app/src/main/java/io/legado/app/help/update/AppReleaseInfo.kt
+++ b/app/src/main/java/io/legado/app/help/update/AppReleaseInfo.kt
@@ -36,23 +36,41 @@ data class GithubRelease(
     @SerializedName("created_at")
     val createdAt: String?
 ) {
-    fun gitReleaseToAppReleaseInfo(): List<AppReleaseInfo> {
+    fun gitReleaseToAppReleaseInfo(
+        supportedAbis: List<String> = Build.SUPPORTED_ABIS.asList()
+    ): List<AppReleaseInfo> {
         assets ?: throw NoStackTraceException("获取新版本出错")
 
         val version = tagName
-        val abi = Build.SUPPORTED_ABIS.firstOrNull() ?: ""
-        val abiSuffix = when {
-            abi.contains("arm64") -> "arm64-v8a"
-            abi.contains("armeabi") -> "armeabi-v7a"
-            else -> ""
-        }
-
-        return assets
-            .filter { it.isValid }
-            .filter { asset ->
-                abiSuffix.isEmpty() || asset.name.contains(abiSuffix, ignoreCase = true)
-            }
+        return selectCompatibleAssets(assets, supportedAbis)
             .map { it.assetToAppReleaseInfo(isPreRelease, body, version) }
+    }
+}
+
+private val releaseAbiSuffixes = listOf(
+    "arm64-v8a",
+    "armeabi-v7a",
+    "x86_64",
+    "x86"
+)
+
+internal fun selectCompatibleAssets(
+    assets: List<Asset>,
+    supportedAbis: List<String>
+): List<Asset> {
+    val validAssets = assets.filter { it.isValid }
+
+    supportedAbis.forEach { supportedAbi ->
+        val matchingAssets = validAssets.filter { asset ->
+            asset.name.contains(supportedAbi, ignoreCase = true)
+        }
+        if (matchingAssets.isNotEmpty()) return matchingAssets
+    }
+
+    return validAssets.filter { asset ->
+        releaseAbiSuffixes.none { abiSuffix ->
+            asset.name.contains(abiSuffix, ignoreCase = true)
+        }
     }
 }
 

--- a/app/src/main/java/io/legado/app/help/update/AppUpdateGitHub.kt
+++ b/app/src/main/java/io/legado/app/help/update/AppUpdateGitHub.kt
@@ -10,9 +10,22 @@ import io.legado.app.help.http.text
 import io.legado.app.utils.GSON
 import io.legado.app.utils.fromJsonArray
 import io.legado.app.utils.fromJsonObject
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.withTimeoutOrNull
+import okhttp3.Headers
+import okhttp3.Request
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
 
 object AppUpdateGitHub : AppUpdate.AppUpdateInterface {
+
+    private const val repoPath = "HapeLee/legado-with-MD3"
+    private const val githubApiBaseUrl = "https://api.github.com/repos/$repoPath/releases"
+    private const val updateManifestBaseUrl =
+        "https://raw.githubusercontent.com/$repoPath/update-manifests"
+    private const val manifestTimeoutMillis = 2500L
 
     private val checkVariant: AppVariant
         get() = when (AppConfig.updateToVariant) {
@@ -22,55 +35,96 @@ object AppUpdateGitHub : AppUpdate.AppUpdateInterface {
             else -> AppConst.appInfo.appVariant
         }
 
-    private suspend fun getLatestRelease(): List<AppReleaseInfo> {
-        val url = if (checkVariant == AppVariant.OFFICIAL)
-            "https://api.github.com/repos/HapeLee/legado-with-MD3/releases/latest"
-        else
-            "https://api.github.com/repos/HapeLee/legado-with-MD3/releases"
+    private suspend fun getLatestRelease(variant: AppVariant): List<AppReleaseInfo> {
+        val releases = getManifestReleases(variant) ?: getApiReleases(variant)
+        return releases
+            .flatMap { it.gitReleaseToAppReleaseInfo() }
+            .sortedByDescending { it.createdAt }
+    }
 
-        val res = okHttpClient.newCallResponse { url(url) }
-        if (!res.isSuccessful) throw NoStackTraceException("获取新版本出错(${res.code})")
+    private suspend fun getManifestReleases(variant: AppVariant): List<GithubRelease>? {
+        val releases = when (variant) {
+            AppVariant.OFFICIAL -> listOfNotNull(getManifestRelease(AppVariant.OFFICIAL))
+            AppVariant.BETA_RELEASE -> listOfNotNull(getManifestRelease(AppVariant.BETA_RELEASE))
+            AppVariant.ALL -> listOfNotNull(
+                getManifestRelease(AppVariant.OFFICIAL),
+                getManifestRelease(AppVariant.BETA_RELEASE)
+            )
+            else -> emptyList()
+        }
+        val expectedCount = if (variant == AppVariant.ALL) 2 else 1
+        return releases.takeIf { it.size == expectedCount }
+    }
 
-        val body = res.body.text()
-        if (body.isBlank()) throw NoStackTraceException("获取新版本出错")
-
-        return when (checkVariant) {
-            AppVariant.BETA_RELEASE -> {
-                val releases = GSON.fromJsonArray<GithubRelease>(body)
-                    .getOrElse { throw NoStackTraceException("解析失败 ${it.localizedMessage}") }
-
-                releases.filter { it.isPreRelease }
-                    .flatMap { it.gitReleaseToAppReleaseInfo() }
-                    .sortedByDescending { it.createdAt }
+    private suspend fun getManifestRelease(variant: AppVariant): GithubRelease? {
+        val channel = when (variant) {
+            AppVariant.OFFICIAL -> "official"
+            AppVariant.BETA_RELEASE -> "beta"
+            else -> return null
+        }
+        return try {
+            withTimeoutOrNull(manifestTimeoutMillis) {
+                val response = okHttpClient.newCallResponse {
+                    url("$updateManifestBaseUrl/$channel.json")
+                }
+                response.use {
+                    if (!it.isSuccessful) return@withTimeoutOrNull null
+                    val release = GSON.fromJsonObject<GithubRelease>(it.body.text()).getOrNull()
+                        ?: return@withTimeoutOrNull null
+                    val expectedPreRelease = variant == AppVariant.BETA_RELEASE
+                    release.takeIf {
+                        it.isPreRelease == expectedPreRelease &&
+                            it.assets.orEmpty().any { asset -> asset.isValid }
+                    }
+                }
             }
+        } catch (error: CancellationException) {
+            throw error
+        } catch (_: Exception) {
+            null
+        }
+    }
 
-            AppVariant.OFFICIAL -> {
-                val release = GSON.fromJsonObject<GithubRelease>(body)
-                    .getOrElse { throw NoStackTraceException("解析失败 ${it.localizedMessage}") }
-
-                release.gitReleaseToAppReleaseInfo()
-                    .sortedByDescending { it.createdAt }
+    private suspend fun getApiReleases(variant: AppVariant): List<GithubRelease> {
+        if (variant == AppVariant.ALL) {
+            val releases = parseReleaseList(getGithubApiBody(githubApiBaseUrl))
+            val latestOfficial = try {
+                GSON.fromJsonObject<GithubRelease>(
+                    getGithubApiBody("$githubApiBaseUrl/latest")
+                ).getOrThrow()
+            } catch (error: CancellationException) {
+                throw error
+            } catch (_: Exception) {
+                null
             }
+            return (listOfNotNull(latestOfficial) + releases).distinctBy { it.tagName }
+        }
 
-            AppVariant.ALL -> {
-                val releases = GSON.fromJsonArray<GithubRelease>(body)
+        val url = if (variant == AppVariant.OFFICIAL) {
+            "$githubApiBaseUrl/latest"
+        } else {
+            githubApiBaseUrl
+        }
+        val body = getGithubApiBody(url)
+        return when (variant) {
+            AppVariant.OFFICIAL -> listOf(
+                GSON.fromJsonObject<GithubRelease>(body)
                     .getOrElse { throw NoStackTraceException("解析失败 ${it.localizedMessage}") }
-
-                releases.flatMap { it.gitReleaseToAppReleaseInfo() }
-                    .sortedByDescending { it.createdAt }
-            }
-
+            )
+            AppVariant.BETA_RELEASE -> parseReleaseList(body)
+                .filter { it.isPreRelease }
             else -> emptyList()
         }
     }
 
-    suspend fun getReleaseByTag(tag: String): AppUpdate.UpdateInfo? {
-        val url = "https://api.github.com/repos/HapeLee/legado-with-MD3/releases/tags/$tag"
-        val res = okHttpClient.newCallResponse { url(url) }
-        if (!res.isSuccessful) return null
+    private fun parseReleaseList(body: String): List<GithubRelease> {
+        return GSON.fromJsonArray<GithubRelease>(body)
+            .getOrElse { throw NoStackTraceException("解析失败 ${it.localizedMessage}") }
+    }
 
-        val body = res.body.text()
-        val release = GSON.fromJsonObject<GithubRelease>(body).getOrElse { return null }
+    suspend fun getReleaseByTag(tag: String): AppUpdate.UpdateInfo? {
+        val manifestRelease = findManifestRelease(tag)
+        val release = manifestRelease ?: getApiReleaseByTag(tag) ?: return null
         val info = release.gitReleaseToAppReleaseInfo().firstOrNull() ?: return null
 
         return AppUpdate.UpdateInfo(
@@ -81,15 +135,61 @@ object AppUpdateGitHub : AppUpdate.AppUpdateInterface {
         )
     }
 
+    private suspend fun findManifestRelease(tag: String): GithubRelease? {
+        val variants = if (tag.contains("beta", ignoreCase = true)) {
+            listOf(AppVariant.BETA_RELEASE, AppVariant.OFFICIAL)
+        } else {
+            listOf(AppVariant.OFFICIAL, AppVariant.BETA_RELEASE)
+        }
+        variants.forEach { variant ->
+            getManifestRelease(variant)?.let { release ->
+                if (release.tagName == tag) return release
+            }
+        }
+        return null
+    }
+
+    private suspend fun getApiReleaseByTag(tag: String): GithubRelease? {
+        val response = okHttpClient.newCallResponse {
+            url("$githubApiBaseUrl/tags/$tag")
+            addGithubApiHeaders()
+        }
+        response.use {
+            if (it.code == 404) return null
+            val body = it.body.text()
+            if (!it.isSuccessful) throw githubApiException(it.code, it.headers, body)
+            return GSON.fromJsonObject<GithubRelease>(body).getOrNull()
+        }
+    }
+
+    private suspend fun getGithubApiBody(url: String): String {
+        val response = okHttpClient.newCallResponse {
+            url(url)
+            addGithubApiHeaders()
+        }
+        response.use {
+            val body = it.body.text()
+            if (!it.isSuccessful) throw githubApiException(it.code, it.headers, body)
+            if (body.isBlank()) throw NoStackTraceException("获取新版本出错")
+            return body
+        }
+    }
+
+    private fun Request.Builder.addGithubApiHeaders() {
+        header("Accept", "application/vnd.github+json")
+        header("X-GitHub-Api-Version", "2026-03-10")
+    }
+
     override fun check(scope: CoroutineScope): Coroutine<AppUpdate.UpdateInfo> {
         return Coroutine.async(scope) {
             val currentVersion = AppConst.appInfo.versionName
-            val releases = getLatestRelease()
+            val variant = checkVariant
+            val releases = getLatestRelease(variant)
 
-            val filtered = if (checkVariant == AppVariant.ALL) {
+            val filtered = if (variant == AppVariant.ALL) {
                 releases
             } else {
-                releases.filter { it.appVariant == checkVariant }
+                releases.filter { it.appVariant == variant }
             }
 
             val latest = filtered.firstOrNull { r ->
@@ -165,4 +265,40 @@ object AppUpdateGitHub : AppUpdate.AppUpdateInterface {
     fun String.versionCompare(other: String): Int {
         return SemVer.parse(this).compareTo(SemVer.parse(other))
     }
+}
+
+internal fun githubApiException(
+    code: Int,
+    headers: Headers,
+    body: String,
+    zoneId: ZoneId = ZoneId.systemDefault()
+): NoStackTraceException {
+    if (code == 403 || code == 429) {
+        val retryAfter = headers["Retry-After"]?.toLongOrNull()
+        if (retryAfter != null) {
+            return NoStackTraceException("GitHub API 请求受限，请在 $retryAfter 秒后重试")
+        }
+        if (headers["X-RateLimit-Remaining"] == "0") {
+            val resetAt = formatRateLimitReset(headers["X-RateLimit-Reset"], zoneId)
+            val message = resetAt?.let { "GitHub API 请求额度已用完，请在 $it 后重试" }
+                ?: "GitHub API 请求额度已用完，请稍后重试"
+            return NoStackTraceException(message)
+        }
+        return NoStackTraceException("GitHub API 暂时限制请求，请稍后重试")
+    }
+
+    val detail = GSON.fromJsonObject<Map<String, String>>(body)
+        .getOrNull()
+        ?.get("message")
+        ?.takeIf { it.isNotBlank() }
+    return NoStackTraceException(
+        detail?.let { "获取新版本出错($code): $it" }
+            ?: "获取新版本出错($code)"
+    )
+}
+
+private fun formatRateLimitReset(value: String?, zoneId: ZoneId): String? {
+    val epochSeconds = value?.toLongOrNull() ?: return null
+    return DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")
+        .format(Instant.ofEpochSecond(epochSeconds).atZone(zoneId))
 }

--- a/app/src/main/java/io/legado/app/ui/config/otherConfig/OtherConfig.kt
+++ b/app/src/main/java/io/legado/app/ui/config/otherConfig/OtherConfig.kt
@@ -17,6 +17,11 @@ object OtherConfig {
         "official_version"
     )
 
+    var autoCheckUpdateOnStart by prefDelegate(
+        PreferKey.autoCheckUpdateOnStart,
+        false
+    )
+
     var webServiceAutoStart by prefDelegate(
         PreferKey.webServiceAutoStart,
         false

--- a/app/src/main/java/io/legado/app/ui/config/otherConfig/OtherConfigScreen.kt
+++ b/app/src/main/java/io/legado/app/ui/config/otherConfig/OtherConfigScreen.kt
@@ -118,6 +118,13 @@ fun OtherConfigScreen(
                 )
 
                 SwitchSettingItem(
+                    title = stringResource(R.string.auto_check_update_on_start_title),
+                    description = stringResource(R.string.auto_check_update_on_start_summary),
+                    checked = OtherConfig.autoCheckUpdateOnStart,
+                    onCheckedChange = { OtherConfig.autoCheckUpdateOnStart = it }
+                )
+
+                SwitchSettingItem(
                     title = stringResource(R.string.web_service_auto_start),
                     checked = OtherConfig.webServiceAutoStart,
                     onCheckedChange = { OtherConfig.webServiceAutoStart = it }

--- a/app/src/main/java/io/legado/app/ui/main/MainActivity.kt
+++ b/app/src/main/java/io/legado/app/ui/main/MainActivity.kt
@@ -77,6 +77,7 @@ open class MainActivity : BaseComposeActivity(), VariableDialog.Callback {
         private const val KEY_RESTORE_READ_ALOUD = "restoreReadAloud"
         private const val KEY_RESTORE_READ_IN_BOOKSHELF = "restoreReadInBookshelf"
         private const val KEY_RESTORE_READ_CHAPTER_CHANGED = "restoreReadChapterChanged"
+        private val startupUpdateCheckGate = ProcessStartupUpdateCheckGate()
 
         @Volatile
         var hasActiveReadBookRoute: Boolean = false
@@ -165,6 +166,9 @@ open class MainActivity : BaseComposeActivity(), VariableDialog.Callback {
         restoredReadBookRoute = savedInstanceState?.restoreReadBookRoute()
         super.onCreate(savedInstanceState)
 
+        val shouldAutoCheckUpdate = startupUpdateCheckGate.consume(
+            OtherConfig.autoCheckUpdateOnStart
+        )
         if (checkStartupRoute()) return
 
         // 智能自启：如果上次是手动开启状态（web_service_auto 为 true），则自启
@@ -185,6 +189,9 @@ open class MainActivity : BaseComposeActivity(), VariableDialog.Callback {
                 viewModel.upAllBookToc()
             }
             viewModel.postLoad()
+            if (shouldAutoCheckUpdate) {
+                checkUpdateOnStart()
+            }
         }
     }
 
@@ -331,6 +338,13 @@ open class MainActivity : BaseComposeActivity(), VariableDialog.Callback {
             }
             else -> false
         }
+    }
+
+    private fun checkUpdateOnStart() {
+        AppUpdateGitHub.check(lifecycleScope)
+            .onSuccess { updateInfo ->
+                showDialogFragment(UpdateDialog(updateInfo))
+            }
     }
 
     /**

--- a/app/src/main/java/io/legado/app/ui/main/ProcessStartupUpdateCheckGate.kt
+++ b/app/src/main/java/io/legado/app/ui/main/ProcessStartupUpdateCheckGate.kt
@@ -1,0 +1,10 @@
+package io.legado.app.ui.main
+
+import java.util.concurrent.atomic.AtomicBoolean
+
+internal class ProcessStartupUpdateCheckGate {
+
+    private val consumed = AtomicBoolean(false)
+
+    fun consume(enabled: Boolean): Boolean = !consumed.getAndSet(true) && enabled
+}

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1393,6 +1393,8 @@
     <string name="start_chapter">起始章</string>
     <string name="update_to_variant_title">检查更新查找版本</string>
     <string name="update_to_variant_summary">检查更新时查找其他签名版本</string>
+    <string name="auto_check_update_on_start_title">启动时自动检测更新</string>
+    <string name="auto_check_update_on_start_summary">仅在应用进程完全重新启动时检测，从后台返回不会触发</string>
     <string name="default_version">当前</string>
     <string name="official_version">正式版</string>
     <string name="beta_release_version">测试版</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -1221,6 +1221,8 @@
     <string name="start_chapter">開始篇章</string>
     <string name="update_to_variant_title">检查更新查找版本</string>
     <string name="update_to_variant_summary">检查更新时查找其他签名版本</string>
+    <string name="auto_check_update_on_start_title">啟動時自動檢查更新</string>
+    <string name="auto_check_update_on_start_summary">僅在應用程式程序完全重新啟動時檢查，從背景返回不會觸發</string>
     <string name="default_version">当前</string>
     <string name="official_version">正式版</string>
     <string name="beta_release_version">测试版</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1225,6 +1225,8 @@
     <string name="start_chapter">開始篇章</string>
     <string name="update_to_variant_title">检查更新查找版本</string>
     <string name="update_to_variant_summary">检查更新时查找其他签名版本</string>
+    <string name="auto_check_update_on_start_title">啟動時自動檢查更新</string>
+    <string name="auto_check_update_on_start_summary">僅在應用程式程序完全重新啟動時檢查，從背景返回不會觸發</string>
     <string name="default_version">当前</string>
     <string name="official_version">正式版</string>
     <string name="beta_release_version">测试版</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1429,6 +1429,8 @@
     <string name="start_chapter">Start Chapter</string>
     <string name="update_to_variant_title">Check Updates for Variants</string>
     <string name="update_to_variant_summary">Look for other signature variants when checking for updates</string>
+    <string name="auto_check_update_on_start_title">Check for updates on startup</string>
+    <string name="auto_check_update_on_start_summary">Only checks after the app process fully restarts; returning from the background will not trigger a check</string>
     <string name="default_version">Current</string>
     <string name="official_version">Official</string>
     <string name="beta_release_version">Beta</string>

--- a/app/src/test/java/io/legado/app/help/update/AppReleaseInfoTest.kt
+++ b/app/src/test/java/io/legado/app/help/update/AppReleaseInfoTest.kt
@@ -1,0 +1,68 @@
+package io.legado.app.help.update
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AppReleaseInfoTest {
+
+    @Test
+    fun `falls back to next supported abi when preferred apk is missing`() {
+        val selected = selectCompatibleAssets(
+            assets = listOf(
+                asset("legado-1.0.0-armeabi-v7a.apk"),
+                asset("legado-1.0.0-x86.apk")
+            ),
+            supportedAbis = listOf("arm64-v8a", "armeabi-v7a")
+        )
+
+        assertEquals(listOf("legado-1.0.0-armeabi-v7a.apk"), selected.map { it.name })
+    }
+
+    @Test
+    fun `uses universal apk when no supported abi apk exists`() {
+        val selected = selectCompatibleAssets(
+            assets = listOf(
+                asset("legado-1.0.0.apk"),
+                asset("legado-1.0.0-x86.apk")
+            ),
+            supportedAbis = listOf("arm64-v8a", "armeabi-v7a")
+        )
+
+        assertEquals(listOf("legado-1.0.0.apk"), selected.map { it.name })
+    }
+
+    @Test
+    fun `does not select an incompatible abi when universal apk is missing`() {
+        val selected = selectCompatibleAssets(
+            assets = listOf(asset("legado-1.0.0-x86.apk")),
+            supportedAbis = listOf("arm64-v8a", "armeabi-v7a")
+        )
+
+        assertEquals(emptyList<Asset>(), selected)
+    }
+
+    @Test
+    fun `prefers the highest priority supported abi`() {
+        val selected = selectCompatibleAssets(
+            assets = listOf(
+                asset("legado-1.0.0.apk"),
+                asset("legado-1.0.0-armeabi-v7a.apk"),
+                asset("legado-1.0.0-arm64-v8a.apk")
+            ),
+            supportedAbis = listOf("arm64-v8a", "armeabi-v7a")
+        )
+
+        assertEquals(listOf("legado-1.0.0-arm64-v8a.apk"), selected.map { it.name })
+    }
+
+    private fun asset(name: String) = Asset(
+        apkUrl = "https://example.com/$name",
+        contentType = "application/vnd.android.package-archive",
+        createdAt = "2026-07-13T00:00:00Z",
+        downloadCount = 0,
+        id = name.hashCode(),
+        name = name,
+        state = "uploaded",
+        url = "https://api.example.com/$name"
+    )
+}

--- a/app/src/test/java/io/legado/app/help/update/AppReleaseInfoTest.kt
+++ b/app/src/test/java/io/legado/app/help/update/AppReleaseInfoTest.kt
@@ -42,6 +42,26 @@ class AppReleaseInfoTest {
     }
 
     @Test
+    fun `x86 does not match x86_64 apk`() {
+        val selected = selectCompatibleAssets(
+            assets = listOf(asset("legado-1.0.0-x86_64.apk")),
+            supportedAbis = listOf("x86")
+        )
+
+        assertEquals(emptyList<Asset>(), selected)
+    }
+
+    @Test
+    fun `armeabi does not match armeabi-v7a apk`() {
+        val selected = selectCompatibleAssets(
+            assets = listOf(asset("legado-1.0.0-armeabi-v7a.apk")),
+            supportedAbis = listOf("armeabi")
+        )
+
+        assertEquals(emptyList<Asset>(), selected)
+    }
+
+    @Test
     fun `prefers the highest priority supported abi`() {
         val selected = selectCompatibleAssets(
             assets = listOf(

--- a/app/src/test/java/io/legado/app/help/update/AppUpdateGitHubTest.kt
+++ b/app/src/test/java/io/legado/app/help/update/AppUpdateGitHubTest.kt
@@ -1,0 +1,57 @@
+package io.legado.app.help.update
+
+import okhttp3.Headers
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.time.ZoneOffset
+
+class AppUpdateGitHubTest {
+
+    @Test
+    fun `primary rate limit reports reset time`() {
+        val error = githubApiException(
+            code = 403,
+            headers = headers(
+                "X-RateLimit-Remaining", "0",
+                "X-RateLimit-Reset", "1783936049"
+            ),
+            body = "",
+            zoneId = ZoneOffset.UTC
+        )
+
+        assertEquals(
+            "GitHub API 请求额度已用完，请在 2026-07-13 09:47 后重试",
+            error.message
+        )
+    }
+
+    @Test
+    fun `secondary rate limit honors retry after`() {
+        val error = githubApiException(
+            code = 429,
+            headers = headers("Retry-After", "90"),
+            body = ""
+        )
+
+        assertEquals("GitHub API 请求受限，请在 90 秒后重试", error.message)
+    }
+
+    @Test
+    fun `other api errors preserve github message`() {
+        val error = githubApiException(
+            code = 500,
+            headers = headers(),
+            body = """{"message":"Internal Server Error"}"""
+        )
+
+        assertEquals("获取新版本出错(500): Internal Server Error", error.message)
+    }
+
+    private fun headers(vararg namesAndValues: String): Headers {
+        return Headers.Builder().apply {
+            namesAndValues.asList().chunked(2).forEach { (name, value) ->
+                add(name, value)
+            }
+        }.build()
+    }
+}

--- a/app/src/test/java/io/legado/app/ui/main/ProcessStartupUpdateCheckGateTest.kt
+++ b/app/src/test/java/io/legado/app/ui/main/ProcessStartupUpdateCheckGateTest.kt
@@ -1,0 +1,24 @@
+package io.legado.app.ui.main
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ProcessStartupUpdateCheckGateTest {
+
+    @Test
+    fun `enabled check runs only once per process`() {
+        val gate = ProcessStartupUpdateCheckGate()
+
+        assertTrue(gate.consume(enabled = true))
+        assertFalse(gate.consume(enabled = true))
+    }
+
+    @Test
+    fun `disabled first startup still consumes the process check`() {
+        val gate = ProcessStartupUpdateCheckGate()
+
+        assertFalse(gate.consume(enabled = false))
+        assertFalse(gate.consume(enabled = true))
+    }
+}


### PR DESCRIPTION
设置 高级 里增加启动时自动检测更新开关，默认关闭，开启后，软件启动时会向本仓库发布页面请求更新资源，相关页面复用 关于 页面的检测更新代码，软件进入后台，或没被彻底清理，进程没有彻底结束。用户进入APK，不会发起请求，只有进程彻底结束，用户打开 APK 才会发起请求