### PR TITLE
refactor(theme): 统一输入框背景色实现方式

### DIFF
--- a/app/src/main/java/io/legado/app/ui/book/info/edit/BookInfoEditScreen.kt
+++ b/app/src/main/java/io/legado/app/ui/book/info/edit/BookInfoEditScreen.kt
@@ -196,17 +196,11 @@ fun BookInfoEditContent(
             onCheckedChange = { viewModel.onFixedTypeChange(it) }
         )
         Spacer(modifier = Modifier.height(16.dp))
-        val bookInfoInputColor = ThemeConfig.bookInfoInputColor
-        val inputBackgroundColor = if (bookInfoInputColor != 0) {
-            Color(bookInfoInputColor)
-        } else {
-            Color.Unspecified
-        }
         AppTextField(
             value = uiState.name,
             onValueChange = { viewModel.onNameChange(it) },
             label = stringResource(R.string.book_name),
-            backgroundColor = inputBackgroundColor,
+            backgroundColor = LegadoTheme.colorScheme.surfaceInput,
             modifier = Modifier.fillMaxWidth()
         )
         Spacer(modifier = Modifier.height(8.dp))
@@ -214,7 +208,7 @@ fun BookInfoEditContent(
             value = uiState.author,
             onValueChange = { viewModel.onAuthorChange(it) },
             label = stringResource(R.string.author),
-            backgroundColor = inputBackgroundColor,
+            backgroundColor = LegadoTheme.colorScheme.surfaceInput,
             modifier = Modifier.fillMaxWidth()
         )
         Spacer(modifier = Modifier.height(8.dp))
@@ -222,7 +216,7 @@ fun BookInfoEditContent(
             value = uiState.coverUrl ?: "",
             onValueChange = { viewModel.onCoverUrlChange(it) },
             label = stringResource(R.string.cover_url),
-            backgroundColor = inputBackgroundColor,
+            backgroundColor = LegadoTheme.colorScheme.surfaceInput,
             modifier = Modifier.fillMaxWidth()
         )
         Spacer(modifier = Modifier.height(8.dp))
@@ -230,14 +224,14 @@ fun BookInfoEditContent(
             kindList = uiState.kindList,
             onKindListChange = { viewModel.onKindListChange(it) },
             onReset = { viewModel.resetKinds() },
-            backgroundColor = inputBackgroundColor
+            backgroundColor = LegadoTheme.colorScheme.surfaceInput,
         )
         Spacer(modifier = Modifier.height(8.dp))
         AppTextField(
             value = uiState.intro ?: "",
             onValueChange = { viewModel.onIntroChange(it) },
             label = stringResource(R.string.book_intro),
-            backgroundColor = inputBackgroundColor,
+            backgroundColor = LegadoTheme.colorScheme.surfaceInput,
             modifier = Modifier.fillMaxWidth()
         )
         Spacer(modifier = Modifier.height(8.dp))
@@ -245,7 +239,7 @@ fun BookInfoEditContent(
             value = uiState.remark ?: "",
             onValueChange = { viewModel.onRemarkChange(it) },
             label = stringResource(R.string.book_remark),
-            backgroundColor = inputBackgroundColor,
+            backgroundColor = LegadoTheme.colorScheme.surfaceInput,
             modifier = Modifier.fillMaxWidth()
         )
     }
@@ -269,13 +263,6 @@ fun BookTypeDropdown(
         textFieldState.setTextAndPlaceCursorAtEnd(selectedTypeLabel)
     }
 
-    val bookInfoInputColor = ThemeConfig.bookInfoInputColor
-    val inputBackgroundColor = if (bookInfoInputColor != 0) {
-        Color(bookInfoInputColor)
-    } else {
-        Color.Unspecified
-    }
-
     ExposedDropdownMenuBox(
         modifier = Modifier.padding(horizontal = 8.dp),
         expanded = expanded,
@@ -286,7 +273,7 @@ fun BookTypeDropdown(
             readOnly = true,
             lineLimits = TextFieldLineLimits.SingleLine,
             label = stringResource(R.string.book_type_label),
-            backgroundColor = inputBackgroundColor,
+            backgroundColor = LegadoTheme.colorScheme.surfaceInput,
             trailingIcon = {
                 ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded)
             },

--- a/app/src/main/java/io/legado/app/ui/replace/edit/ReplaceEditScreen.kt
+++ b/app/src/main/java/io/legado/app/ui/replace/edit/ReplaceEditScreen.kt
@@ -45,6 +45,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalFocusManager
@@ -52,6 +53,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
 import io.legado.app.R
+import io.legado.app.ui.theme.LegadoTheme
 import io.legado.app.ui.widget.components.AppFloatingActionButton
 import io.legado.app.ui.widget.components.AppScaffold
 import io.legado.app.ui.widget.components.AppTextField
@@ -213,6 +215,7 @@ fun ReplaceEditScreen(
                     value = state.name,
                     onValueChange = { onIntent(ReplaceEditIntent.OnNameChange(it)) },
                     label = stringResource(R.string.rule_name),
+                    backgroundColor = LegadoTheme.colorScheme.surfaceInput,
                     modifier = Modifier
                         .fillMaxWidth()
                         .onFocusChanged {
@@ -225,7 +228,8 @@ fun ReplaceEditScreen(
                     currentGroup = state.group,
                     allGroups = state.allGroups,
                     onGroupChange = { onIntent(ReplaceEditIntent.OnGroupChange(it)) },
-                    onManageClick = { onIntent(ReplaceEditIntent.ToggleGroupDialog(true)) }
+                    onManageClick = { onIntent(ReplaceEditIntent.ToggleGroupDialog(true)) },
+                    backgroundColor = LegadoTheme.colorScheme.surfaceInput,
                 )
 
                 AppTextField(
@@ -233,6 +237,7 @@ fun ReplaceEditScreen(
                     onValueChange = { onIntent(ReplaceEditIntent.OnPatternChange(it)) },
                     label = stringResource(R.string.match_pattern),
                     placeholder = { AppText(stringResource(R.string.input_regex_or_keyword)) },
+                    backgroundColor = LegadoTheme.colorScheme.surfaceInput,
                     modifier = Modifier
                         .fillMaxWidth()
                         .onFocusChanged {
@@ -245,6 +250,7 @@ fun ReplaceEditScreen(
                     onValueChange = { onIntent(ReplaceEditIntent.OnReplacementChange(it)) },
                     label = stringResource(R.string.replace_with),
                     placeholder = { AppText(stringResource(R.string.input_replacement_or_group)) },
+                    backgroundColor = LegadoTheme.colorScheme.surfaceInput,
                     modifier = Modifier
                         .fillMaxWidth()
                         .onFocusChanged {
@@ -289,6 +295,7 @@ fun ReplaceEditScreen(
                     onValueChange = { onIntent(ReplaceEditIntent.OnScopeChange(it)) },
                     label = stringResource(R.string.specific_scope),
                     placeholder = { AppText(stringResource(R.string.scope_hint)) },
+                    backgroundColor = LegadoTheme.colorScheme.surfaceInput,
                     modifier = Modifier
                         .fillMaxWidth()
                         .onFocusChanged {
@@ -301,6 +308,7 @@ fun ReplaceEditScreen(
                     onValueChange = { onIntent(ReplaceEditIntent.OnExcludeScopeChange(it)) },
                     label = stringResource(R.string.exclude_scope),
                     placeholder = { AppText(stringResource(R.string.exclude_scope_hint)) },
+                    backgroundColor = LegadoTheme.colorScheme.surfaceInput,
                     modifier = Modifier
                         .fillMaxWidth()
                         .onFocusChanged {
@@ -313,6 +321,7 @@ fun ReplaceEditScreen(
                     onValueChange = { onIntent(ReplaceEditIntent.OnTimeoutChange(it)) },
                     label = stringResource(R.string.timeout_ms),
                     placeholder = { AppText("3000") },
+                    backgroundColor = LegadoTheme.colorScheme.surfaceInput,
                     modifier = Modifier.fillMaxWidth()
                 )
 
@@ -337,7 +346,8 @@ fun GroupSelector(
     currentGroup: String,
     allGroups: List<String>,
     onGroupChange: (String) -> Unit,
-    onManageClick: () -> Unit
+    onManageClick: () -> Unit,
+    backgroundColor: Color = Color.Unspecified,
 ) {
     var expanded by remember { mutableStateOf(false) }
 
@@ -351,6 +361,7 @@ fun GroupSelector(
                 value = currentGroup,
                 onValueChange = onGroupChange,
                 label = stringResource(R.string.group),
+                backgroundColor = backgroundColor,
                 placeholder = { AppText("默认") },
                 trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
                 modifier = Modifier

--- a/app/src/main/java/io/legado/app/ui/theme/LegadoTheme.kt
+++ b/app/src/main/java/io/legado/app/ui/theme/LegadoTheme.kt
@@ -75,7 +75,10 @@ data class LegadoColorScheme(
     val cardContainer: Color,
     val onCardContainer: Color,
     val onSheetContent: Color,
-    val cardPrimaryContainer: Color
+    val cardPrimaryContainer: Color,
+
+    /** 输入框背景色，已应用容器背景不透明度 */
+    val surfaceInput: Color,
 )
 
 data class LegadoTypography(

--- a/app/src/main/java/io/legado/app/ui/theme/ThemeColorSchemeOverride.kt
+++ b/app/src/main/java/io/legado/app/ui/theme/ThemeColorSchemeOverride.kt
@@ -75,7 +75,8 @@ fun ColorScheme.toLegadoColorScheme(
         cardContainer = primaryContainer.copy(alpha = 0.5f),
         onCardContainer = primary,
         onSheetContent = surface,
-        cardPrimaryContainer = primaryContainer
+        cardPrimaryContainer = primaryContainer,
+        surfaceInput = surface.copy(alpha = (ThemeConfig.containerOpacity / 100f).coerceIn(0f, 1f))
     )
 }
 

--- a/app/src/main/java/io/legado/app/ui/theme/ThemeComponents.kt
+++ b/app/src/main/java/io/legado/app/ui/theme/ThemeComponents.kt
@@ -188,7 +188,8 @@ fun MiuixThemeWrapper(
                 onCardContainer = miuixColorScheme.onSurface,
                 onSheetContent = miuixColorScheme.surface.copy(alpha = 0.5f),
                 cardPrimaryContainer = miuixColorScheme.primary.copy(alpha = 0.1f)
-                    .compositeOver(miuixColorScheme.surface)
+                    .compositeOver(miuixColorScheme.surface),
+                surfaceInput = miuixColorScheme.surface.copy(alpha = (ThemeConfig.containerOpacity / 100f).coerceIn(0f, 1f))
             )
         }
 


### PR DESCRIPTION
1. 新增surfaceInput颜色字段统一管理输入框背景色
2. 移除硬编码的输入框背景色配置，改用主题统一提供的surfaceInput
3. 移除冗余的ThemeConfig.bookInfoInputColor相关代码

 Fixes: #1748