### PR TITLE
refactor(main, theme): 统一使用LegadoTheme获取主题色

### DIFF
--- a/app/src/main/java/io/legado/app/ui/main/MainScreen.kt
+++ b/app/src/main/java/io/legado/app/ui/main/MainScreen.kt
@@ -189,7 +189,7 @@ fun MainScreen(
     val floatingBarSurfaceColor = if (ThemeConfig.isDeepPersonalizationActive && customSecondaryColor != 0) {
         Color(customSecondaryColor)
     } else {
-        MaterialTheme.colorScheme.surface
+        LegadoTheme.colorScheme.surface
     }
     val floatingBarBackdrop = rememberLayerBackdrop {
         drawRect(floatingBarSurfaceColor)
@@ -376,7 +376,7 @@ fun MainScreen(
                                     )
                                 },
                                 m3IndicatorColor = GlassDefaults.glassColor(
-                                    noBlurColor = MaterialTheme.colorScheme.secondaryContainer,
+                                    noBlurColor = LegadoTheme.colorScheme.secondaryContainer,
                                     blurAlpha = GlassDefaults.ThickBlurAlpha
                                 ),
                                 m3ShowLabel = showLabel && !customIconPath.isNotEmpty(),

--- a/app/src/main/java/io/legado/app/ui/theme/LegadoTheme.kt
+++ b/app/src/main/java/io/legado/app/ui/theme/LegadoTheme.kt
@@ -75,7 +75,10 @@ data class LegadoColorScheme(
     val cardContainer: Color,
     val onCardContainer: Color,
     val onSheetContent: Color,
-    val cardPrimaryContainer: Color
+    val cardPrimaryContainer: Color,
+
+    /** 输入框背景色，已应用容器背景不透明度 */
+    val surfaceInput: Color,
 )
 
 data class LegadoTypography(

--- a/app/src/main/java/io/legado/app/ui/theme/ThemeColorSchemeOverride.kt
+++ b/app/src/main/java/io/legado/app/ui/theme/ThemeColorSchemeOverride.kt
@@ -75,7 +75,8 @@ fun ColorScheme.toLegadoColorScheme(
         cardContainer = primaryContainer.copy(alpha = 0.5f),
         onCardContainer = primary,
         onSheetContent = surface,
-        cardPrimaryContainer = primaryContainer
+        cardPrimaryContainer = primaryContainer,
+        surfaceInput = surface.copy(alpha = (ThemeConfig.containerOpacity / 100f).coerceIn(0f, 1f))
     )
 }
 

--- a/app/src/main/java/io/legado/app/ui/theme/ThemeComponents.kt
+++ b/app/src/main/java/io/legado/app/ui/theme/ThemeComponents.kt
@@ -3,8 +3,10 @@ package io.legado.app.ui.theme
 import android.graphics.Typeface
 import android.net.Uri
 import android.os.Build
+import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.MaterialExpressiveTheme
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.MotionScheme
 import androidx.compose.material3.Shapes
 import androidx.compose.material3.Typography
@@ -188,15 +190,98 @@ fun MiuixThemeWrapper(
                 onCardContainer = miuixColorScheme.onSurface,
                 onSheetContent = miuixColorScheme.surface.copy(alpha = 0.5f),
                 cardPrimaryContainer = miuixColorScheme.primary.copy(alpha = 0.1f)
-                    .compositeOver(miuixColorScheme.surface)
+                    .compositeOver(miuixColorScheme.surface),
+                surfaceInput = miuixColorScheme.surface.copy(alpha = (ThemeConfig.containerOpacity / 100f).coerceIn(0f, 1f))
             )
+        }
+
+        val materialTypography = remember(miuixStyles, customFontFamily) {
+            val base = miuixStylesToM3Typography(miuixStyles)
+            if (customFontFamily != null) {
+                base.copy(
+                    headlineLarge = base.headlineLarge.copy(fontFamily = customFontFamily),
+                    headlineMedium = base.headlineMedium.copy(fontFamily = customFontFamily),
+                    headlineSmall = base.headlineSmall.copy(fontFamily = customFontFamily),
+                    titleLarge = base.titleLarge.copy(fontFamily = customFontFamily),
+                    titleMedium = base.titleMedium.copy(fontFamily = customFontFamily),
+                    titleSmall = base.titleSmall.copy(fontFamily = customFontFamily),
+                    bodyLarge = base.bodyLarge.copy(fontFamily = customFontFamily),
+                    bodyMedium = base.bodyMedium.copy(fontFamily = customFontFamily),
+                    bodySmall = base.bodySmall.copy(fontFamily = customFontFamily),
+                    labelLarge = base.labelLarge.copy(fontFamily = customFontFamily),
+                    labelMedium = base.labelMedium.copy(fontFamily = customFontFamily),
+                    labelSmall = base.labelSmall.copy(fontFamily = customFontFamily)
+                )
+            } else {
+                base
+            }
         }
 
         CompositionLocalProvider(
             LocalLegadoTypography provides legadoTypography,
             LocalLegadoColorScheme provides mappedColorScheme
         ) {
-            AppBackground(darkTheme = darkTheme) { content() }
+            // 将 Miuix 色板（含深度个性化）映射为 M3 ColorScheme，
+            // 使 M3 组件（如 WideNavigationRail）在 Miuix 引擎下获取正确颜色
+            val materialColorScheme = remember(mappedColorScheme) {
+                ColorScheme(
+                    primary = mappedColorScheme.primary,
+                    onPrimary = mappedColorScheme.onPrimary,
+                    primaryContainer = mappedColorScheme.primaryContainer,
+                    onPrimaryContainer = mappedColorScheme.onPrimaryContainer,
+                    inversePrimary = mappedColorScheme.inversePrimary,
+                    secondary = mappedColorScheme.secondary,
+                    onSecondary = mappedColorScheme.onSecondary,
+                    secondaryContainer = mappedColorScheme.secondaryContainer,
+                    onSecondaryContainer = mappedColorScheme.onSecondaryContainer,
+                    tertiary = mappedColorScheme.tertiary,
+                    onTertiary = mappedColorScheme.onTertiary,
+                    tertiaryContainer = mappedColorScheme.tertiaryContainer,
+                    onTertiaryContainer = mappedColorScheme.onTertiaryContainer,
+                    background = mappedColorScheme.background,
+                    onBackground = mappedColorScheme.onBackground,
+                    surface = mappedColorScheme.surface,
+                    onSurface = mappedColorScheme.onSurface,
+                    surfaceVariant = mappedColorScheme.surfaceVariant,
+                    onSurfaceVariant = mappedColorScheme.onSurfaceVariant,
+                    surfaceTint = mappedColorScheme.surfaceTint,
+                    inverseSurface = mappedColorScheme.inverseSurface,
+                    inverseOnSurface = mappedColorScheme.inverseOnSurface,
+                    error = mappedColorScheme.error,
+                    onError = mappedColorScheme.onError,
+                    errorContainer = mappedColorScheme.errorContainer,
+                    onErrorContainer = mappedColorScheme.onErrorContainer,
+                    outline = mappedColorScheme.outline,
+                    outlineVariant = mappedColorScheme.outlineVariant,
+                    scrim = mappedColorScheme.scrim,
+                    surfaceBright = mappedColorScheme.surfaceBright,
+                    surfaceDim = mappedColorScheme.surfaceDim,
+                    surfaceContainer = mappedColorScheme.surfaceContainer,
+                    surfaceContainerHigh = mappedColorScheme.surfaceContainerHigh,
+                    surfaceContainerHighest = mappedColorScheme.surfaceContainerHighest,
+                    surfaceContainerLow = mappedColorScheme.surfaceContainerLow,
+                    surfaceContainerLowest = mappedColorScheme.surfaceContainerLowest,
+                    primaryFixed = mappedColorScheme.primaryFixed,
+                    primaryFixedDim = mappedColorScheme.primaryFixedDim,
+                    onPrimaryFixed = mappedColorScheme.onPrimaryFixed,
+                    onPrimaryFixedVariant = mappedColorScheme.onPrimaryFixedVariant,
+                    secondaryFixed = mappedColorScheme.secondaryFixed,
+                    secondaryFixedDim = mappedColorScheme.secondaryFixedDim,
+                    onSecondaryFixed = mappedColorScheme.onSecondaryFixed,
+                    onSecondaryFixedVariant = mappedColorScheme.onSecondaryFixedVariant,
+                    tertiaryFixed = mappedColorScheme.tertiaryFixed,
+                    tertiaryFixedDim = mappedColorScheme.tertiaryFixedDim,
+                    onTertiaryFixed = mappedColorScheme.onTertiaryFixed,
+                    onTertiaryFixedVariant = mappedColorScheme.onTertiaryFixedVariant,
+                )
+            }
+            MaterialTheme(
+                colorScheme = materialColorScheme,
+                typography = materialTypography,
+                shapes = Shapes()
+            ) {
+                AppBackground(darkTheme = darkTheme) { content() }
+            }
         }
     }
 }


### PR DESCRIPTION
1. 修复MainScreen中误使用MaterialTheme的颜色引用，替换为LegadoTheme
2. 在ThemeComponents中新增M3 MaterialTheme包装，将Miuix色板映射为标准M3 ColorScheme，让M3组件能正确获取主题色
3. 补充了自定义字体相关的typography转换逻辑

Fixes:#1714


开了不同分支修复bug，由于涉及到对同一文件修改，[1764](https://github.com/HapeLee/legado-with-MD3/pull/1764) 还没合并，所有连同一起修改了。已提交缺少的1764中的文件。