### PR TITLE
外观设置界面的一些优化

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -39,6 +39,7 @@
         <activity
             android:name=".ui.main.LauncherW"
             android:enabled="false"
+            android:configChanges="uiMode"
             android:exported="true"
             android:icon="@mipmap/launcherw">
             <intent-filter>
@@ -54,6 +55,7 @@
         <activity
             android:name=".ui.main.Launcher0"
             android:enabled="false"
+            android:configChanges="uiMode"
             android:exported="true"
             android:icon="@mipmap/launcher0">
             <intent-filter>
@@ -70,6 +72,7 @@
         <activity
             android:name=".ui.main.Launcher1"
             android:enabled="false"
+            android:configChanges="uiMode"
             android:exported="true"
             android:icon="@mipmap/launcher1">
             <intent-filter>
@@ -86,6 +89,7 @@
         <activity
             android:name=".ui.main.Launcher2"
             android:enabled="false"
+            android:configChanges="uiMode"
             android:exported="true"
             android:icon="@mipmap/launcher2">
             <intent-filter>
@@ -102,6 +106,7 @@
         <activity
             android:name=".ui.main.Launcher3"
             android:enabled="false"
+            android:configChanges="uiMode"
             android:exported="true"
             android:icon="@mipmap/launcher3">
             <intent-filter>
@@ -118,6 +123,7 @@
         <activity
             android:name=".ui.main.Launcher4"
             android:enabled="false"
+            android:configChanges="uiMode"
             android:exported="true"
             android:icon="@mipmap/launcher4">
             <intent-filter>
@@ -134,6 +140,7 @@
         <activity
             android:name=".ui.main.Launcher5"
             android:enabled="false"
+            android:configChanges="uiMode"
             android:exported="true"
             android:icon="@mipmap/launcher5">
             <intent-filter>
@@ -150,6 +157,7 @@
         <activity
             android:name=".ui.main.Launcher6"
             android:enabled="false"
+            android:configChanges="uiMode"
             android:exported="true"
             android:icon="@mipmap/launcher6">
             <intent-filter>
@@ -166,6 +174,7 @@
         <activity
             android:name=".ui.main.MainActivity"
             android:alwaysRetainTaskState="true"
+            android:configChanges="uiMode"
             android:enableOnBackInvokedCallback="true"
             android:windowSoftInputMode="adjustResize"
             android:exported="true">

--- a/app/src/main/java/io/legado/app/base/BaseActivity.kt
+++ b/app/src/main/java/io/legado/app/base/BaseActivity.kt
@@ -183,6 +183,7 @@ abstract class BaseActivity<VB : ViewBinding>(
             "11" -> setTheme(R.style.Theme_Base_Mujika)
             "12" -> {
                 val colorImagePath = getPrefString(PreferKey.colorImage)
+                var colorImageApplied = false
                 if (!colorImagePath.isNullOrBlank()) {
                     val file = File(colorImagePath)
                     if (file.exists()) {
@@ -199,9 +200,13 @@ abstract class BaseActivity<VB : ViewBinding>(
 
                             DynamicColors.applyToActivityIfAvailable(this, options)
                             bitmap.recycle()
+                            colorImageApplied = true
                         }
                     }
-                }else{
+                }
+                if (!colorImageApplied) {
+                    // 取色图片缺失或解码失败时回退到种子色，
+                    // 否则该 Activity 完全拿不到动态配色，与 Compose 界面不一致
                     DynamicColors.applyToActivityIfAvailable(
                         this,
                         DynamicColorsOptions.Builder()

--- a/app/src/main/java/io/legado/app/base/BaseActivity.kt
+++ b/app/src/main/java/io/legado/app/base/BaseActivity.kt
@@ -168,7 +168,7 @@ abstract class BaseActivity<VB : ViewBinding>(
     open fun initTheme() {
         when (getPrefString("app_theme", "0")) {
             "0" -> {
-                DynamicColors.applyToActivitiesIfAvailable(application)
+                DynamicColors.applyToActivityIfAvailable(this)
             }
             "1" -> setTheme(R.style.Theme_Base_GR)
             "2" -> setTheme(R.style.Theme_Base_Lemon)
@@ -182,9 +182,6 @@ abstract class BaseActivity<VB : ViewBinding>(
             "10" -> setTheme(R.style.Theme_Base_Phoebe)
             "11" -> setTheme(R.style.Theme_Base_Mujika)
             "12" -> {
-                if (AppConfig.customMode == "accent")
-                    setTheme(R.style.ThemeOverlay_WhiteBackground)
-
                 val colorImagePath = getPrefString(PreferKey.colorImage)
                 if (!colorImagePath.isNullOrBlank()) {
                     val file = File(colorImagePath)
@@ -200,18 +197,22 @@ abstract class BaseActivity<VB : ViewBinding>(
                                 .setContentBasedSource(scaledBitmap)
                                 .build()
 
-                            DynamicColors.applyToActivitiesIfAvailable(application, options)
+                            DynamicColors.applyToActivityIfAvailable(this, options)
                             bitmap.recycle()
                         }
                     }
                 }else{
-                    DynamicColors.applyToActivitiesIfAvailable(
-                        application,
+                    DynamicColors.applyToActivityIfAvailable(
+                        this,
                         DynamicColorsOptions.Builder()
                             .setContentBasedSource(application.primaryColor)
                             .build()
                     )
                 }
+
+                // 必须在动态取色之后应用，否则会被动态配色的 surface/background 覆盖
+                if (AppConfig.customMode == "accent")
+                    setTheme(R.style.ThemeOverlay_WhiteBackground)
             }
 
             "13" -> setTheme(R.style.AppTheme_Transparent)

--- a/app/src/main/java/io/legado/app/base/BaseComposeActivity.kt
+++ b/app/src/main/java/io/legado/app/base/BaseComposeActivity.kt
@@ -1,5 +1,6 @@
 package io.legado.app.base
 
+import android.content.res.Configuration
 import android.os.Bundle
 import android.os.Build
 import androidx.activity.compose.setContent
@@ -54,6 +55,18 @@ abstract class BaseComposeActivity(
         }
 
         observeLiveBus()
+    }
+
+    override fun onConfigurationChanged(newConfig: Configuration) {
+        super.onConfigurationChanged(newConfig)
+        // manifest 声明 uiMode configChanges 后，切换深浅色不再 recreate，
+        // 而 AppCompat 手动回调本方法时不会走 View 树分发，需要自己同步给
+        // Compose（LocalConfiguration）并刷新系统栏与背景图
+        window.decorView.dispatchConfigurationChanged(newConfig)
+        setupSystemBar()
+        if (imageBg) {
+            upBackgroundImage()
+        }
     }
 
     open fun setupSystemBar() {

--- a/app/src/main/java/io/legado/app/help/config/ThemeConfigStore.kt
+++ b/app/src/main/java/io/legado/app/help/config/ThemeConfigStore.kt
@@ -49,6 +49,16 @@ object ThemeConfigStore {
         postEvent(EventBus.UP_CONFIG, arrayListOf(2))
     }
 
+    /**
+     * 切换深浅色但不发 RECREATE：Compose 界面通过 ThemeConfig.themeMode 快照状态
+     * 自动换色（保留 ToggleButton 等组件的过渡动画），setDefaultNightMode 只会重建
+     * 未在 manifest 声明 uiMode configChanges 的旧 View Activity
+     */
+    fun applyDayNightLive() {
+        initNightMode()
+        postEvent(EventBus.UP_CONFIG, arrayListOf(2))
+    }
+
     fun applyDayNightInit(context: Context) {
         initNightMode()
     }

--- a/app/src/main/java/io/legado/app/lib/prefs/ThemeCardPreference.kt
+++ b/app/src/main/java/io/legado/app/lib/prefs/ThemeCardPreference.kt
@@ -4,8 +4,6 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.content.res.ColorStateList
 import android.graphics.Color
-import android.os.Handler
-import android.os.Looper
 import android.util.AttributeSet
 import android.view.ContextThemeWrapper
 import android.view.LayoutInflater
@@ -20,11 +18,9 @@ import com.google.android.material.card.MaterialCardView
 import io.legado.app.R
 import io.legado.app.constant.EventBus
 import io.legado.app.constant.PreferKey
-import io.legado.app.lib.dialogs.alert
 import io.legado.app.ui.config.themeConfig.ThemeConfig
 import io.legado.app.utils.getPrefString
 import io.legado.app.utils.postEvent
-import io.legado.app.utils.restart
 import io.legado.app.utils.toastOnUi
 import splitties.init.appCtx
 
@@ -98,29 +94,12 @@ class ThemeCardPreference(context: Context, attrs: AttributeSet) : Preference(co
                             ThemeConfig.containerOpacity = 0
                         }
                     }
-                    val oldValue = currentValue
                     currentValue = value
                     persistString(value)
                     callChangeListener(value)
                     ThemeConfig.appTheme = value
                     notifyDataSetChanged()
-                    val isDynamicSwitch = (oldValue == "12" || value == "12")
-                    Handler(Looper.getMainLooper()).postDelayed({
-                        if (isDynamicSwitch) {
-                            context.alert(context.getString(R.string.restart_required_message)) {
-                                okButton {
-                                    Handler(Looper.getMainLooper()).postDelayed({
-                                        context.restart()
-                                    }, 100)
-                                }
-                                cancelButton {
-                                    context.toastOnUi(R.string.restart_later_message)
-                                }
-                            }
-                        } else {
-                            postEvent(EventBus.RECREATE, "")
-                        }
-                    }, 100)
+                    postEvent(EventBus.RECREATE, "")
                 }
             }
         }

--- a/app/src/main/java/io/legado/app/ui/config/PrefDelegate.kt
+++ b/app/src/main/java/io/legado/app/ui/config/PrefDelegate.kt
@@ -61,6 +61,10 @@ fun <T> prefDelegate(
         @Volatile
         private var currentValue: T = defaultValue
         private val scope = CoroutineScope(kotlinx.coroutines.Dispatchers.IO)
+
+        // 单并发调度器保证同一 key 的 DataStore 写入按提交顺序落盘
+        @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+        private val dsWriteDispatcher = kotlinx.coroutines.Dispatchers.IO.limitedParallelism(1)
         private var dsObserverJob: Job? = null
 
         init {
@@ -131,9 +135,10 @@ fun <T> prefDelegate(
                     is Long -> appCtx.putPrefLong(key, value)
                     is Float -> appCtx.putPrefFloat(key, value)
                 }
-                // 同步写入 DataStore，确保持久化后再返回
-                runCatching {
-                    runBlocking {
+                // 异步串行写入 DataStore；runBlocking 会把整文件重写 + fsync
+                // 挂在调用线程（通常是主线程的点击回调）上，造成明显掉帧
+                scope.launch(dsWriteDispatcher) {
+                    runCatching {
                         when (value) {
                             is String? -> DsSync.putString(key, value)
                             is Int -> DsSync.putInt(key, value)

--- a/app/src/main/java/io/legado/app/ui/config/customTheme/CustomThemeScreen.kt
+++ b/app/src/main/java/io/legado/app/ui/config/customTheme/CustomThemeScreen.kt
@@ -23,11 +23,9 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringArrayResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import com.google.android.material.color.DynamicColors
-import com.google.android.material.color.DynamicColorsOptions
 import io.legado.app.R
+import io.legado.app.constant.EventBus
 import io.legado.app.lib.theme.ThemeStore
-import io.legado.app.lib.theme.primaryColor
 import io.legado.app.ui.config.themeConfig.ThemeConfig
 import io.legado.app.ui.theme.adaptiveContentPadding
 import io.legado.app.ui.widget.components.AppScaffold
@@ -39,6 +37,7 @@ import io.legado.app.ui.widget.components.settingItem.SwitchSettingItem
 import io.legado.app.ui.widget.components.topbar.GlassMediumFlexibleTopAppBar
 import io.legado.app.ui.widget.components.topbar.GlassTopAppBarDefaults
 import io.legado.app.ui.widget.components.topbar.TopBarNavigationButton
+import io.legado.app.utils.postEvent
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -245,12 +244,7 @@ fun CustomThemeScreen(
                     ThemeStore.editTheme(context)
                         .primaryColor(color)
                         .apply()
-                    DynamicColors.applyToActivitiesIfAvailable(
-                        context.applicationContext as android.app.Application,
-                        DynamicColorsOptions.Builder()
-                            .setContentBasedSource(context.primaryColor)
-                            .build()
-                    )
+                    postEvent(EventBus.RECREATE, "")
                 }
             }
         )

--- a/app/src/main/java/io/legado/app/ui/config/themeConfig/ThemeConfigScreen.kt
+++ b/app/src/main/java/io/legado/app/ui/config/themeConfig/ThemeConfigScreen.kt
@@ -234,7 +234,7 @@ fun ThemeConfigScreen(
                             onValueChange = { mode ->
                                 selectedThemeMode = mode
                                 ThemeConfig.themeMode = mode
-                                ThemeConfigStore.applyDayNight(context)
+                                ThemeConfigStore.applyDayNightLive()
                             }
                         )
 
@@ -274,7 +274,7 @@ fun ThemeConfigScreen(
                             onModeSelected = { mode ->
                                 selectedThemeMode = mode
                                 ThemeConfig.themeMode = mode
-                                ThemeConfigStore.applyDayNight(context)
+                                ThemeConfigStore.applyDayNightLive()
                             }
                         )
                     }
@@ -975,15 +975,20 @@ fun ThemeColorButton(
     customNightSeedColor: Int,
     onClick: () -> Unit
 ) {
-    val colors = getThemeColorPalette(
-        context = context,
-        value = value,
-        isDark = isDark,
-        isAmoled = isAmoled,
-        paletteStyle = paletteStyle,
-        customLightSeedColor = customLightSeedColor,
-        customNightSeedColor = customNightSeedColor
-    )
+    // 配色方案由种子色实时生成，开销不小，缓存避免无关重组时重复计算
+    val colors = remember(
+        value, isDark, isAmoled, paletteStyle, customLightSeedColor, customNightSeedColor
+    ) {
+        getThemeColorPalette(
+            context = context,
+            value = value,
+            isDark = isDark,
+            isAmoled = isAmoled,
+            paletteStyle = paletteStyle,
+            customLightSeedColor = customLightSeedColor,
+            customNightSeedColor = customNightSeedColor
+        )
+    }
     val borderWidth by animateDpAsState(
         targetValue = if (isSelected) 2.dp else 0.dp,
         label = "borderWidth"
@@ -1076,15 +1081,19 @@ fun ThemeCard(
     customLightSeedColor: Int,
     customNightSeedColor: Int
 ) {
-    val colors = getThemeColors(
-        context = context,
-        value = value,
-        isDark = isDark,
-        isAmoled = isAmoled,
-        paletteStyle = paletteStyle,
-        customLightSeedColor = customLightSeedColor,
-        customNightSeedColor = customNightSeedColor
-    )
+    val colors = remember(
+        value, isDark, isAmoled, paletteStyle, customLightSeedColor, customNightSeedColor
+    ) {
+        getThemeColors(
+            context = context,
+            value = value,
+            isDark = isDark,
+            isAmoled = isAmoled,
+            paletteStyle = paletteStyle,
+            customLightSeedColor = customLightSeedColor,
+            customNightSeedColor = customNightSeedColor
+        )
+    }
 
     Column(
         horizontalAlignment = Alignment.CenterHorizontally

--- a/app/src/main/java/io/legado/app/ui/config/themeConfig/ThemeConfigScreen.kt
+++ b/app/src/main/java/io/legado/app/ui/config/themeConfig/ThemeConfigScreen.kt
@@ -3,8 +3,6 @@ package io.legado.app.ui.config.themeConfig
 import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
-import android.os.Handler
-import android.os.Looper
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedVisibility
@@ -85,7 +83,6 @@ import io.legado.app.ui.widget.components.AppScaffold
 import io.legado.app.ui.widget.components.FontFolderState
 import io.legado.app.ui.widget.components.FontSelectSheet
 import io.legado.app.ui.widget.components.SplicedColumnGroup
-import io.legado.app.ui.widget.components.alert.AppAlertDialog
 import io.legado.app.ui.widget.components.button.series.SmallPlainButton
 import io.legado.app.ui.widget.components.card.GlassCard
 import io.legado.app.ui.widget.components.dialog.ColorPickerSheet
@@ -99,7 +96,6 @@ import io.legado.app.ui.widget.components.topbar.GlassMediumFlexibleTopAppBar
 import io.legado.app.ui.widget.components.topbar.GlassTopAppBarDefaults
 import io.legado.app.ui.widget.components.topbar.TopBarNavigationButton
 import io.legado.app.utils.postEvent
-import io.legado.app.utils.restart
 import io.legado.app.utils.takePersistablePermissionSafely
 import io.legado.app.utils.toastOnUi
 import org.koin.androidx.compose.koinViewModel
@@ -119,7 +115,6 @@ fun ThemeConfigScreen(
     var selectedThemeMode by remember { mutableStateOf(ThemeConfig.themeMode) }
     var selectedTheme by remember { mutableStateOf(ThemeConfig.appTheme) }
     var useMiuixMonet by remember { mutableStateOf(ThemeConfig.useMiuixMonet) }
-    var showRestartDialog by remember { mutableStateOf(false) }
     var showLauncherIconPicker by remember { mutableStateOf(false) }
     var showBorderColorPicker by remember { mutableStateOf(false) }
     var showNavIconSheet by remember { mutableStateOf(false) }
@@ -268,7 +263,7 @@ fun ThemeConfigScreen(
                                     selectedTheme = newTheme
                                     ThemeConfig.appTheme = newTheme
                                     if (oldTheme != newTheme) {
-                                        showRestartDialog = true
+                                        postEvent(EventBus.RECREATE, "")
                                     }
                                 }
                             )
@@ -310,15 +305,9 @@ fun ThemeConfigScreen(
                                         ThemeConfig.containerOpacity = 0
                                     }
                                 }
-                                val oldTheme = selectedTheme
                                 selectedTheme = theme
                                 ThemeConfig.appTheme = theme
-                                val isDynamicSwitch = (oldTheme == "12" || theme == "12")
-                                if (isDynamicSwitch) {
-                                    showRestartDialog = true
-                                } else {
-                                    postEvent(EventBus.RECREATE, "")
-                                }
+                                postEvent(EventBus.RECREATE, "")
                             }
                         )
                     }
@@ -817,25 +806,6 @@ fun ThemeConfigScreen(
 
         }
     }
-
-
-    AppAlertDialog(
-        show = showRestartDialog,
-        onDismissRequest = { showRestartDialog = false },
-        title = stringResource(R.string.restart_required_message),
-        onConfirm = {
-            showRestartDialog = false
-            Handler(Looper.getMainLooper()).postDelayed({
-                context.restart()
-            }, 100)
-        },
-        confirmText = stringResource(R.string.ok),
-        onDismiss = {
-            showRestartDialog = false
-            context.toastOnUi(R.string.restart_later_message)
-        },
-        dismissText = stringResource(R.string.cancel)
-    )
 
 
     BackgroundImageManageSheet(

--- a/app/src/main/java/io/legado/app/ui/theme/AppTheme.kt
+++ b/app/src/main/java/io/legado/app/ui/theme/AppTheme.kt
@@ -131,12 +131,16 @@ private fun AppThemeActual(
     }
 
     // 6. 构造 Legado 主题模式数据
+    // themeMode 用 effectiveDarkTheme 归一化（System 已在上面解析成明确的深浅色），
+    // 这样"跟随系统"和"深色"在系统深色下产生相等的 LegadoThemeMode，
+    // staticCompositionLocalOf 不会触发全树重组
     val themeColors = remember(
         colorScheme, effectiveDarkTheme, themeSeedColor, paletteStyleValue, composeEngine,
-        appThemeMode, themeModeValue
+        appThemeMode
     ) {
         val paletteStyle = ThemeResolver.resolvePaletteStyle(paletteStyleValue)
-        val colorSchemeMode = ThemeResolver.resolveColorSchemeMode(themeModeValue)
+        val colorSchemeMode =
+            if (effectiveDarkTheme) ColorSchemeMode.Dark else ColorSchemeMode.Light
         LegadoThemeMode(
             colorScheme = colorScheme,
             isDark = effectiveDarkTheme,

--- a/app/src/main/java/io/legado/app/ui/widget/components/FontSelectSheet.kt
+++ b/app/src/main/java/io/legado/app/ui/widget/components/FontSelectSheet.kt
@@ -80,7 +80,8 @@ fun FontSelectSheet(
             SmallPlainButton(
                 onClick = onOpenFolderPicker,
                 icon = folderIcon,
-                contentDescription = folderContentDescription,
+                contentDescription = folderContentDescription
+                    ?: stringResource(R.string.select_folder),
             )
         },
     ) {


### PR DESCRIPTION
## 改动内容

本分支包含三个相互关联的主题系统修复：

### 1. 切换自定义主题不再需要重启（c97fff4）
`DynamicColors.applyToActivitiesIfAvailable` 只注册全局 ActivityLifecycleCallbacks：仅对之后创建的 Activity 生效、且 Material 未提供注销接口导致 callback 无限堆积。
改用 per-activity 的 `applyToActivityIfAvailable(this, …)`（`initTheme()` 在 `super.onCreate()` 之前，等价于官方 onActivityPreCreated 时机），配色立即作用于当前 Activity，`RECREATE` 事件即可完成换肤，重启弹窗随之移除。注意 `ThemeOverlay_WhiteBackground` 必须在动态取色之后应用，否则 accent 模式白底会被动态配色覆盖（代码内有注释锁定该约束）。

### 2. 深浅色切换保留 Compose 动效（9db2bff）
原来点主题模式按钮会经 `setDefaultNightMode`（uiMode 配置变更）+ `EventBus.RECREATE` 双重触发 Activity 重建，M3 Expressive ToggleButton 的形状 morph 动画第一帧就被销毁，表现为"生硬变形"。而 `prefDelegate` 底层是 `mutableStateOf`，`AppTheme` 本身就是响应式的，根本不需要重建：
- MainActivity（含 8 个 Launcher 别名入口）manifest 声明 `android:configChanges="uiMode"`；
- `BaseComposeActivity.onConfigurationChanged` 手动分发配置给 View 树（同步 `LocalConfiguration`）并刷新系统栏/背景图；
- 新增 `ThemeConfigStore.applyDayNightLive()`：只设置夜间模式不发 RECREATE，旧 View Activity 仍由 `setDefaultNightMode` 按需重建。

同一提交内的三项点击延迟优化（实测同一 5 连点序列，debug 包）：
- `PrefDelegate` 的 `runBlocking { DataStore 写入 }` 改为串行异步（`limitedParallelism(1)` 保序），不再在主线程点击回调里等整文件重写 + fsync；
- 主题预览配色（`ThemeCard`/`ThemeColorButton` 的 MaterialKolor 种子色生成）加 `remember` 缓存；
- `LegadoThemeMode.themeMode` 用 `effectiveDarkTheme` 归一化为明确的 Dark/Light，系统深色下「跟随系统」↔「深色」不再触发 `staticCompositionLocalOf` 全树重组。

实测：90/95 分位帧耗时 16/17ms → 8/8ms，Missed Vsync 5 → 0；不改变实际深浅的点击完全无卡帧，仅真实深浅切换保留一帧全应用换色的重组。

实机效果非常顺滑，点按反馈很快了：

https://github.com/user-attachments/assets/909a9682-d602-4c67-9ccd-e9c72d124a01



### 3. 取色图片失效时回退种子色（e8efc0d）
per-activity 化后暴露的边界：`colorImage` 路径存在但文件丢失/解码失败时整个分支不应用任何配色（旧全局 callback 的堆积残留恰好掩盖了这个洞），旧 View 界面会落回 manifest 默认主题。现回退到种子色路径，与"未设置图片"行为一致。

## 审阅提示

- `uiMode` 只加在 MainActivity 家族（Compose 宿主）上；旧 View Activity 不声明，仍靠重建适配深浅色，行为不变。
- `applyDayNight()`（带 RECREATE）保留给 Restore 备份恢复与旧偏好界面等调用方，行为不变。
- 主题色卡片 / 种子色选取仍走即时 RECREATE（有意保留，后续可用同样思路去除）。
- accent 白底（`customMode == "accent"`）当前无 UI 写入口，仅存量配置用户命中，需带存量配置的设备验证。
- 已实机验证（Samsung 真机，debug 包）：深浅色切换动效、无重启换色、配置持久化（强杀进程后仍生效）；单测中 `SearchContentRepositoryTest` 的失败在干净工作树上同样存在（Koin 未启动的存量测试环境问题），与本分支无关。

🤖 Generated with [Claude Code](https://claude.com/claude-code)