### PR TITLE
fix: 同步窗口背景色与 Compose 主题背景色

### DIFF
--- a/app/src/main/java/io/legado/app/base/BaseComposeActivity.kt
+++ b/app/src/main/java/io/legado/app/base/BaseComposeActivity.kt
@@ -85,7 +85,8 @@ abstract class BaseComposeActivity(
         } catch (_: Exception) {}
     }
 
-    private var hasWindowBgImage = false
+    protected var hasWindowBgImage = false
+    private var lastWindowBgColor: Int? = null
 
     /**
      * 窗口背景色与 Compose 主题背景色同步。
@@ -102,7 +103,11 @@ abstract class BaseComposeActivity(
         }
         SideEffect {
             if (!hasWindowBgImage) {
-                window.setBackgroundDrawable(backgroundColor.toArgb().toDrawable())
+                val colorInt = backgroundColor.toArgb()
+                if (lastWindowBgColor != colorInt) {
+                    window.setBackgroundDrawable(colorInt.toDrawable())
+                    lastWindowBgColor = colorInt
+                }
             }
         }
     }

--- a/app/src/main/java/io/legado/app/base/BaseComposeActivity.kt
+++ b/app/src/main/java/io/legado/app/base/BaseComposeActivity.kt
@@ -6,6 +6,8 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.graphics.toArgb
 import androidx.core.graphics.drawable.toDrawable
 import androidx.core.view.WindowCompat
 import io.legado.app.constant.EventBus
@@ -13,6 +15,8 @@ import io.legado.app.constant.Theme
 import io.legado.app.help.config.AppConfig
 import io.legado.app.help.config.ThemeConfigStore
 import io.legado.app.ui.theme.AppTheme
+import io.legado.app.ui.theme.LegadoTheme
+import io.legado.app.ui.theme.ThemeResolver
 import io.legado.app.utils.disableAutoFill
 import io.legado.app.utils.fullScreen
 import io.legado.app.utils.observeEvent
@@ -20,6 +24,7 @@ import io.legado.app.utils.setStatusBarColorAuto
 import io.legado.app.utils.themeColor
 import io.legado.app.utils.toggleSystemBar
 import io.legado.app.utils.windowSize
+import top.yukonga.miuix.kmp.theme.MiuixTheme
 
 abstract class BaseComposeActivity(
     val fullScreen: Boolean = true,
@@ -45,6 +50,7 @@ abstract class BaseComposeActivity(
         // Compose 入口
         setContent {
             AppTheme {
+                SyncWindowBackground()
                 Content()
             }
         }
@@ -73,9 +79,32 @@ abstract class BaseComposeActivity(
     open fun upBackgroundImage() {
         try {
             ThemeConfigStore.getBgImage(this, windowManager.windowSize)?.let {
+                hasWindowBgImage = true
                 window.setBackgroundDrawable(it.toDrawable(resources))
             }
         } catch (_: Exception) {}
+    }
+
+    private var hasWindowBgImage = false
+
+    /**
+     * 窗口背景色与 Compose 主题背景色同步。
+     * 窗口背景默认来自 XML 主题，与运行时计算的 Compose 主题色存在色差；
+     * 转场淡出、启动交接等场景露出窗口背景时会出现颜色跳变。
+     */
+    @Composable
+    private fun SyncWindowBackground() {
+        if (transparent) return
+        val backgroundColor = if (ThemeResolver.isMiuixEngine(LegadoTheme.composeEngine)) {
+            MiuixTheme.colorScheme.surface
+        } else {
+            LegadoTheme.colorScheme.background
+        }
+        SideEffect {
+            if (!hasWindowBgImage) {
+                window.setBackgroundDrawable(backgroundColor.toArgb().toDrawable())
+            }
+        }
     }
 
     open fun observeLiveBus() {

--- a/app/src/main/java/io/legado/app/ui/main/MainActivity.kt
+++ b/app/src/main/java/io/legado/app/ui/main/MainActivity.kt
@@ -12,6 +12,7 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedContentTransitionScope
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionLayout
+import androidx.compose.animation.core.FastOutLinearInEasing
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.LinearOutSlowInEasing
 import androidx.compose.animation.core.tween
@@ -261,6 +262,9 @@ open class MainActivity : BaseComposeActivity(), VariableDialog.Callback {
                 ),
                 sceneStrategies = listOf(SinglePaneSceneStrategy()),
                 transitionSpec = {
+                    // 溶解式转场：两个界面在恒定底色上淡出/淡入（窗口背景色已与
+                    // Compose 主题同步，见 BaseComposeActivity.SyncWindowBackground）。
+                    // 淡出必须用加速曲线，减速曲线会让旧内容开头几帧骤然消失
                     (slideIntoContainer(
                         towards = AnimatedContentTransitionScope.SlideDirection.Start,
                         animationSpec = tween(durationMillis = 480, easing = FastOutSlowInEasing),
@@ -277,7 +281,7 @@ open class MainActivity : BaseComposeActivity(), VariableDialog.Callback {
                     ) + fadeOut(
                         animationSpec = tween(
                             durationMillis = 360,
-                            easing = LinearOutSlowInEasing
+                            easing = FastOutLinearInEasing
                         )
                     ))
                 },


### PR DESCRIPTION

## fix: 修复界面转场时的“闪屏/变色”问题

### 问题

从「我的」进入设置、AI 对话、标签规则、阅读记录、缓存管理、关于等 Compose 路由(以及「设置」下所有二级入口)时,旧界面会先“闪”成另一种颜色,再向左滑出,观感突兀。

### 原因

问题由两个因素叠加造成:

1. **窗口背景与 Compose 主题存在色差(根因)**。Activity 的窗口背景色来自 XML 主题,而各界面的背景色由 Compose 主题引擎在运行时计算(种子色/动态取色),两者不保证一致。平时界面不透明、窗口背景不可见,色差无从暴露。
2. **转场动画把色差暴露了出来**。`NavDisplay` 的转场是溶解式设计(滑动 + 淡出淡入),退出界面淡出时露出底下的窗口背景,合成结果 `屏幕色×α + 窗口色×(1−α)` 把两套颜色的差异混了出来,视觉上就是整屏“变色”。此外退出侧 `fadeOut` 误用了减速曲线(`LinearOutSlowInEasing`,先快后慢),透明度在开头几帧骤降,进一步放大成“闪”。

### 修改

- **`BaseComposeActivity`**:新增 `SyncWindowBackground()`,在 Compose 主题解析后将窗口背景同步为当前主题背景色(Material 引擎取 `colorScheme.background`,Miuix 引擎取 `surface`,与 `AppScaffold` 取色一致)。用户配置了背景图时不覆盖;`transparent` 窗口跳过;主题运行时切换自动重新同步。窗口层与界面层从此恒为同色,淡出不再露出异色。
- **`MainActivity`**:转场保持原有的溶解式设计不变,仅将退出侧 `fadeOut` 曲线修正为加速曲线(`FastOutLinearInEasing`)——旧内容在滑动的大部分时间保持可见,最后快速溶出,符合 fade-through 规范时序。

### 验证
修改前：
<img width="1080" height="2340" alt="Screenshot_20260717_003013_Legado" src="https://github.com/user-attachments/assets/2c03ae26-df70-48a1-b84f-481f0336378f" />

修改后：
<img width="1080" height="2340" alt="Screenshot_20260717_002843_legadoD" src="https://github.com/user-attachments/assets/4107ebdb-8d45-475a-a821-b722a5d5b152" />
