### PR TITLE
存储收敛与免重启改造

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -33,6 +33,7 @@
         android:enableOnBackInvokedCallback="true"
         android:hardwareAccelerated="true"
         android:supportsRtl="true"
+        android:autoStoreLocales="true"
         android:theme="@style/Base.AppTheme"
         tools:ignore="AllowBackup,GoogleAppIndexingWarning,UnusedAttribute">
         <!-- 图标0 -->
@@ -514,6 +515,12 @@
         <service
             android:name=".service.DownloadService"
             android:foregroundServiceType="dataSync" />
+
+        <service
+            android:name="androidx.appcompat.app.AppLocalesMetadataHolderService"
+            android:enabled="true"
+            android:exported="false"
+            tools:ignore="ExportedService" />
 
         <receiver
             android:name=".receiver.MediaButtonReceiver"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -33,7 +33,6 @@
         android:enableOnBackInvokedCallback="true"
         android:hardwareAccelerated="true"
         android:supportsRtl="true"
-        android:autoStoreLocales="true"
         android:theme="@style/Base.AppTheme"
         tools:ignore="AllowBackup,GoogleAppIndexingWarning,UnusedAttribute">
         <!-- 图标0 -->
@@ -520,7 +519,11 @@
             android:name="androidx.appcompat.app.AppLocalesMetadataHolderService"
             android:enabled="true"
             android:exported="false"
-            tools:ignore="ExportedService" />
+            tools:ignore="ExportedService">
+            <meta-data
+                android:name="autoStoreLocales"
+                android:value="true" />
+        </service>
 
         <receiver
             android:name=".receiver.MediaButtonReceiver"

--- a/app/src/main/java/io/legado/app/App.kt
+++ b/app/src/main/java/io/legado/app/App.kt
@@ -34,7 +34,6 @@ import io.legado.app.data.entities.rule.BookInfoRule
 import io.legado.app.data.entities.rule.ContentRule
 import io.legado.app.data.entities.rule.ExploreRule
 import io.legado.app.data.entities.rule.SearchRule
-import io.legado.app.data.repository.SettingsRepository
 import io.legado.app.di.appDatabaseModule
 import io.legado.app.di.appModule
 import io.legado.app.help.AppFreezeMonitor
@@ -143,10 +142,6 @@ class App : Application(), ImageLoaderFactory {
             LogUtils.init(this@App)
             LogUtils.d("App", "onCreate")
             LogUtils.logDeviceInfo()
-            // 确保 DataStore 迁移后 SP 中的主题配置值未丢失
-            kotlin.runCatching {
-                get<SettingsRepository>().postMigrationSync()
-            }
             //预下载Cronet so
             Cronet.preDownload()
             createNotificationChannels()

--- a/app/src/main/java/io/legado/app/App.kt
+++ b/app/src/main/java/io/legado/app/App.kt
@@ -46,6 +46,7 @@ import io.legado.app.help.LifecycleHelp
 import io.legado.app.help.RuleBigDataHelp
 import io.legado.app.help.book.BookHelp
 import io.legado.app.help.config.AppConfig
+import io.legado.app.help.config.AppConfigStore
 import io.legado.app.help.config.ReadBookConfig
 import io.legado.app.help.config.ThemeConfigStore
 import io.legado.app.help.config.ThemeConfigStore.applyDayNightInit
@@ -87,6 +88,9 @@ class App : Application(), ImageLoaderFactory {
     }
 
     override fun onCreate() {
+        // 首行初始化设置快照层：同步预加载 DataStore（触发 SP 迁移），
+        // 之后所有 getPref* 门面读取均为纯内存查找，须先于一切主题/配置读取
+        AppConfigStore.init(this)
         startKoin {
             androidContext(this@App)
             modules(appDatabaseModule, appModule)

--- a/app/src/main/java/io/legado/app/App.kt
+++ b/app/src/main/java/io/legado/app/App.kt
@@ -1,9 +1,5 @@
 package io.legado.app
 
-import androidx.appcompat.app.AppCompatDelegate
-import androidx.core.os.LocaleListCompat
-import io.legado.app.ui.config.otherConfig.OtherConfig
-import java.util.Locale
 import android.app.Application
 import android.app.Notification
 import android.app.NotificationChannel
@@ -13,6 +9,7 @@ import android.content.pm.ApplicationInfo
 import android.content.res.Configuration
 import android.graphics.BitmapFactory
 import android.os.Build
+import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.graphics.scale
 import coil.ImageLoader
 import coil.ImageLoaderFactory
@@ -50,6 +47,7 @@ import io.legado.app.help.RuleBigDataHelp
 import io.legado.app.help.book.BookHelp
 import io.legado.app.help.config.AppConfig
 import io.legado.app.help.config.AppConfigStore
+import io.legado.app.help.config.LocalConfig
 import io.legado.app.help.config.ReadBookConfig
 import io.legado.app.help.config.ThemeConfigStore
 import io.legado.app.help.config.ThemeConfigStore.applyDayNightInit
@@ -63,10 +61,11 @@ import io.legado.app.help.storage.Backup
 import io.legado.app.lib.theme.primaryColor
 import io.legado.app.model.BookCover
 import io.legado.app.ui.book.read.page.entities.TextLine
+import io.legado.app.ui.config.otherConfig.OtherConfig
+import io.legado.app.ui.config.otherConfig.appLocaleListFor
 import io.legado.app.utils.ChineseUtils
 import io.legado.app.utils.FirebaseManager
 import io.legado.app.utils.LogUtils
-import io.legado.app.utils.defaultSharedPreferences
 import io.legado.app.utils.getPrefBoolean
 import io.legado.app.utils.getPrefString
 import io.legado.app.utils.isDebuggable
@@ -94,19 +93,15 @@ class App : Application(), ImageLoaderFactory {
         // 首行初始化设置快照层：同步预加载 DataStore（触发 SP 迁移），
         // 之后所有 getPref* 门面读取均为纯内存查找，须先于一切主题/配置读取
         AppConfigStore.init(this)
-        val storedLanguage = OtherConfig.language
-        if (storedLanguage != "auto") {
-            val appCompatLocales = AppCompatDelegate.getApplicationLocales()
-            if (appCompatLocales.isEmpty) {
-                val localeList = when (storedLanguage) {
-                    "zh" -> LocaleListCompat.create(Locale.SIMPLIFIED_CHINESE)
-                    "tw" -> LocaleListCompat.create(Locale.TRADITIONAL_CHINESE)
-                    "en" -> LocaleListCompat.create(Locale.ENGLISH)
-                    else -> null
-                }
-                if (localeList != null) {
-                    AppCompatDelegate.setApplicationLocales(localeList)
-                }
+        // 一次性迁移：把旧版语言偏好写入 AppCompat per-app locales，之后交由
+        // autoStoreLocales 持久化。不能每次启动都执行——API 33+ 上会覆盖用户在
+        // 系统设置里选择的应用语言，API <33 上此时 AppCompat 存储尚未加载、
+        // getApplicationLocales() 恒为空，isEmpty 守卫会形同虚设
+        if (!LocalConfig.appLocaleMigrated) {
+            LocalConfig.appLocaleMigrated = true
+            val localeList = appLocaleListFor(OtherConfig.language)
+            if (!localeList.isEmpty && AppCompatDelegate.getApplicationLocales().isEmpty) {
+                AppCompatDelegate.setApplicationLocales(localeList)
             }
         }
         startKoin {

--- a/app/src/main/java/io/legado/app/App.kt
+++ b/app/src/main/java/io/legado/app/App.kt
@@ -1,5 +1,9 @@
 package io.legado.app
 
+import androidx.appcompat.app.AppCompatDelegate
+import androidx.core.os.LocaleListCompat
+import io.legado.app.ui.config.otherConfig.OtherConfig
+import java.util.Locale
 import android.app.Application
 import android.app.Notification
 import android.app.NotificationChannel
@@ -90,6 +94,21 @@ class App : Application(), ImageLoaderFactory {
         // 首行初始化设置快照层：同步预加载 DataStore（触发 SP 迁移），
         // 之后所有 getPref* 门面读取均为纯内存查找，须先于一切主题/配置读取
         AppConfigStore.init(this)
+        val storedLanguage = OtherConfig.language
+        if (storedLanguage != "auto") {
+            val appCompatLocales = AppCompatDelegate.getApplicationLocales()
+            if (appCompatLocales.isEmpty) {
+                val localeList = when (storedLanguage) {
+                    "zh" -> LocaleListCompat.create(Locale.SIMPLIFIED_CHINESE)
+                    "tw" -> LocaleListCompat.create(Locale.TRADITIONAL_CHINESE)
+                    "en" -> LocaleListCompat.create(Locale.ENGLISH)
+                    else -> null
+                }
+                if (localeList != null) {
+                    AppCompatDelegate.setApplicationLocales(localeList)
+                }
+            }
+        }
         startKoin {
             androidContext(this@App)
             modules(appDatabaseModule, appModule)

--- a/app/src/main/java/io/legado/app/App.kt
+++ b/app/src/main/java/io/legado/app/App.kt
@@ -136,7 +136,6 @@ class App : Application(), ImageLoaderFactory {
         }
         oldConfig = Configuration(resources.configuration)
         registerActivityLifecycleCallbacks(LifecycleHelp)
-        defaultSharedPreferences.registerOnSharedPreferenceChangeListener(AppConfig)
         Coroutine.async {
             AppWebDav.upConfig()
         }

--- a/app/src/main/java/io/legado/app/base/AppContextWrapper.kt
+++ b/app/src/main/java/io/legado/app/base/AppContextWrapper.kt
@@ -1,44 +1,25 @@
 package io.legado.app.base
 
-import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.Context
 import android.content.res.Configuration
-import android.os.Build
-import android.os.LocaleList
-import io.legado.app.ui.config.otherConfig.OtherConfig
 import io.legado.app.ui.config.themeConfig.ThemeConfig
 import io.legado.app.utils.sysConfiguration
-import java.util.Locale
 
 
 @Suppress("unused")
 object AppContextWrapper {
 
-    fun wrap(context: Context): Context {
-        val newConfig = Configuration(context.resources.configuration)
-        val targetLocale = getSetLocale()
-        newConfig.setLocale(targetLocale)
-        newConfig.setLocales(LocaleList(targetLocale))
-        newConfig.fontScale = getFontScale(context)
-        return context.createConfigurationContext(newConfig)
-    }
-
-    fun applyLocaleAndFont(activity: Activity) {
+    fun applyFont(activity: Activity) {
         val config = activity.resources.configuration
-        val locale = getSetLocale()
         val fontScale = getFontScale(activity)
 
         val newConfig = Configuration(config)
-        newConfig.setLocale(locale)
-        newConfig.setLocales(LocaleList(locale))
         newConfig.fontScale = fontScale
 
         @Suppress("DEPRECATION")
         activity.resources.updateConfiguration(newConfig, activity.resources.displayMetrics)
     }
-
-
 
     fun getFontScale(context: Context): Float {
         var fontScale = ThemeConfig.fontScale / 10f
@@ -46,62 +27,6 @@ object AppContextWrapper {
             fontScale = sysConfiguration.fontScale
         }
         return fontScale
-    }
-
-    /**
-     * 当前系统语言
-     */
-    @SuppressLint("ObsoleteSdkInt")
-    private fun getSystemLocale(): Locale {
-        val locale: Locale
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) { //7.0有多语言设置获取顶部的语言
-            locale = sysConfiguration.locales.get(0)
-        } else {
-            @Suppress("DEPRECATION")
-            locale = sysConfiguration.locale
-        }
-        return locale
-    }
-
-    /**
-     * 当前App语言
-     */
-    @SuppressLint("ObsoleteSdkInt")
-    private fun getAppLocale(context: Context): Locale {
-        val locale: Locale
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            locale = context.resources.configuration.locales[0]
-        } else {
-            @Suppress("DEPRECATION")
-            locale = context.resources.configuration.locale
-        }
-        return locale
-
-    }
-
-    /**
-     * 当前设置语言
-     */
-    private fun getSetLocale(): Locale {
-        return when (OtherConfig.language) {
-            "zh" -> Locale.SIMPLIFIED_CHINESE
-            "tw" -> Locale.TRADITIONAL_CHINESE
-            "en" -> Locale.ENGLISH
-            else -> getSystemLocale()
-        }
-    }
-
-    /**
-     * 判断App语言和设置语言是否相同
-     */
-    fun isSameWithSetting(context: Context): Boolean {
-        val locale = getAppLocale(context)
-        val language = locale.language
-        val country = locale.country
-        val pfLocale = getSetLocale()
-        val pfLanguage = pfLocale.language
-        val pfCountry = pfLocale.country
-        return language == pfLanguage && country == pfCountry
     }
 
 }

--- a/app/src/main/java/io/legado/app/base/BaseActivity.kt
+++ b/app/src/main/java/io/legado/app/base/BaseActivity.kt
@@ -79,7 +79,7 @@ abstract class BaseActivity<VB : ViewBinding>(
     override fun onCreate(savedInstanceState: Bundle?) {
         initTheme()
         window.decorView.disableAutoFill()
-        AppContextWrapper.applyLocaleAndFont(this)
+        AppContextWrapper.applyFont(this)
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             val enable = !AppConfig.isPredictiveBackEnabled
             if (enable) {

--- a/app/src/main/java/io/legado/app/base/BaseComposeActivity.kt
+++ b/app/src/main/java/io/legado/app/base/BaseComposeActivity.kt
@@ -39,7 +39,7 @@ abstract class BaseComposeActivity(
 
     override fun onCreate(savedInstanceState: Bundle?) {
         window.decorView.disableAutoFill()
-        AppContextWrapper.applyLocaleAndFont(this)
+        AppContextWrapper.applyFont(this)
 
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()

--- a/app/src/main/java/io/legado/app/data/repository/SettingsRepository.kt
+++ b/app/src/main/java/io/legado/app/data/repository/SettingsRepository.kt
@@ -16,11 +16,8 @@ import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.core.stringSetPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import io.legado.app.constant.PreferKey
-import io.legado.app.utils.defaultSharedPreferences
-import io.legado.app.utils.removePref
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import java.io.IOException
 
@@ -161,44 +158,6 @@ class SettingsRepository(private val context: Context) {
         }
     }
 
-    /**
-     * DataStore 迁移后同步校验：确保 SP 中的主题配置值未被迁移过程丢失。
-     *
-     * SharedPreferencesMigration 在首次访问 DataStore 时运行，将 SP 值复制到 DataStore。
-     * 在某些场景下（进程被杀、ROM 行为等），迁移可能导致 SP 中的值丢失。
-     * 此方法从 DataStore 读取关键主题配置，如果 SP 中缺失则补写回去。
-     */
-    suspend fun postMigrationSync() {
-        val prefs = dataStore.data.first()
-        val sp = context.defaultSharedPreferences
-        val themeKeys = listOf(
-            PreferKey.composeEngine,
-            PreferKey.appTheme,
-            PreferKey.themeMode,
-            PreferKey.paletteStyle,
-            PreferKey.materialVersion,
-            PreferKey.customContrast,
-            PreferKey.customMode,
-        )
-        var needsWrite = false
-        val editor = mutableMapOf<String, String>()
-        for (key in themeKeys) {
-            if (!sp.contains(key)) {
-                val dsValue = runCatching { prefs[stringPreferencesKey(key)] }.getOrNull()
-                if (dsValue != null) {
-                    editor[key] = dsValue
-                    needsWrite = true
-                }
-            }
-        }
-        if (needsWrite) {
-            sp.edit {
-                editor.forEach { (key, value) ->
-                    putString(key, value)
-                }
-            }
-        }
-    }
 
     // 移除配置
     suspend fun remove(key: String) {
@@ -209,6 +168,5 @@ class SettingsRepository(private val context: Context) {
             preferences.remove(longPreferencesKey(key))
             preferences.remove(floatPreferencesKey(key))
         }
-        context.removePref(key)
     }
 }

--- a/app/src/main/java/io/legado/app/data/repository/SettingsRepository.kt
+++ b/app/src/main/java/io/legado/app/data/repository/SettingsRepository.kt
@@ -1,7 +1,6 @@
 package io.legado.app.data.repository
 
 import android.content.Context
-import androidx.core.content.edit
 import androidx.datastore.core.DataMigration
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.SharedPreferencesMigration
@@ -63,7 +62,6 @@ internal object ShowBrightnessViewMigration : DataMigration<Preferences> {
 /**
  * 设置仓储
  * 以 DataStore 为唯一写入源，读取以 DataStore 为准。
- * SP 同步由 PrefDelegate 双写保证（阶段 1），此处不再回写 SP。
  */
 class SettingsRepository(private val context: Context) {
 
@@ -138,26 +136,6 @@ class SettingsRepository(private val context: Context) {
 
     suspend fun putStringSet(key: String, value: Set<String>) =
         updatePreference(stringSetPreferencesKey(key), value)
-
-    // 批量从 Map 恢复到 DataStore (用于兼容 Restore 逻辑)
-    suspend fun batchPutFromMap(map: Map<String, *>) {
-        dataStore.edit { preferences ->
-            map.forEach { (key, value) ->
-                when (value) {
-                    is String -> preferences[stringPreferencesKey(key)] = value
-                    is Int -> preferences[intPreferencesKey(key)] = value
-                    is Boolean -> preferences[booleanPreferencesKey(key)] = value
-                    is Long -> preferences[longPreferencesKey(key)] = value
-                    is Float -> preferences[floatPreferencesKey(key)] = value
-                    is Set<*> -> {
-                        @Suppress("UNCHECKED_CAST")
-                        preferences[stringSetPreferencesKey(key)] = value as Set<String>
-                    }
-                }
-            }
-        }
-    }
-
 
     // 移除配置
     suspend fun remove(key: String) {

--- a/app/src/main/java/io/legado/app/help/WebDavManager.kt
+++ b/app/src/main/java/io/legado/app/help/WebDavManager.kt
@@ -1,6 +1,5 @@
 package io.legado.app.help
 
-import android.content.SharedPreferences
 import android.net.Uri
 import io.legado.app.constant.PreferKey
 import io.legado.app.data.appDb
@@ -8,6 +7,7 @@ import io.legado.app.data.entities.Book
 import io.legado.app.data.entities.BookProgress
 import io.legado.app.exception.NoStackTraceException
 import io.legado.app.help.config.AppConfig
+import io.legado.app.help.config.AppConfigStore
 import io.legado.app.help.config.LocalConfig
 import io.legado.app.help.storage.Backup
 import io.legado.app.help.storage.BackupRestoreLock
@@ -24,7 +24,6 @@ import io.legado.app.utils.GSON
 import io.legado.app.utils.NetworkUtils
 import io.legado.app.utils.UrlUtil
 import io.legado.app.utils.compress.ZipUtils
-import io.legado.app.utils.defaultSharedPreferences
 import io.legado.app.utils.fromJsonObject
 import io.legado.app.utils.isJson
 import io.legado.app.utils.normalizeFileName
@@ -34,12 +33,13 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import splitties.init.appCtx
 import java.io.File
 import kotlin.coroutines.cancellation.CancellationException
 
@@ -67,9 +67,8 @@ sealed class WebDavState {
 }
 
 class WebDavManager(
-    private val prefs: SharedPreferences = appCtx.defaultSharedPreferences,
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO
-) : SharedPreferences.OnSharedPreferenceChangeListener {
+) {
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
     private val configFlow = MutableStateFlow(readConfig())
@@ -79,12 +78,22 @@ class WebDavManager(
     private var refreshJob: Job? = null
 
     init {
-        prefs.registerOnSharedPreferenceChangeListener(this)
+        scope.launch {
+            merge(
+                AppConfigStore.observeString(PreferKey.webDavUrl).drop(1),
+                AppConfigStore.observeString(PreferKey.webDavAccount).drop(1),
+                AppConfigStore.observeString(PreferKey.webDavPassword).drop(1),
+                AppConfigStore.observeString(PreferKey.webDavDir).drop(1),
+                AppConfigStore.observeString(PreferKey.webDavDeviceName).drop(1),
+            ).collect {
+                configFlow.value = readConfig()
+                refresh()
+            }
+        }
         refresh()
     }
 
     fun close() {
-        prefs.unregisterOnSharedPreferenceChangeListener(this)
         scope.cancel()
     }
 
@@ -270,18 +279,6 @@ class WebDavManager(
                     appDb.bookDao.update(book)
                 }
             }
-        }
-    }
-
-    override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences?, key: String?) {
-        if (key == PreferKey.webDavUrl
-            || key == PreferKey.webDavAccount
-            || key == PreferKey.webDavPassword
-            || key == PreferKey.webDavDir
-            || key == PreferKey.webDavDeviceName
-        ) {
-            configFlow.value = readConfig()
-            refresh()
         }
     }
 

--- a/app/src/main/java/io/legado/app/help/WebDavManager.kt
+++ b/app/src/main/java/io/legado/app/help/WebDavManager.kt
@@ -37,6 +37,7 @@ import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -66,6 +67,7 @@ sealed class WebDavState {
     ) : WebDavState()
 }
 
+@OptIn(kotlinx.coroutines.FlowPreview::class)
 class WebDavManager(
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO
 ) {
@@ -85,7 +87,7 @@ class WebDavManager(
                 AppConfigStore.observeString(PreferKey.webDavPassword).drop(1),
                 AppConfigStore.observeString(PreferKey.webDavDir).drop(1),
                 AppConfigStore.observeString(PreferKey.webDavDeviceName).drop(1),
-            ).collect {
+            ).debounce(100).collect {
                 configFlow.value = readConfig()
                 refresh()
             }

--- a/app/src/main/java/io/legado/app/help/config/AppConfig.kt
+++ b/app/src/main/java/io/legado/app/help/config/AppConfig.kt
@@ -3,7 +3,6 @@ package io.legado.app.help.config
 import io.legado.app.BuildConfig
 import io.legado.app.constant.PreferKey
 import io.legado.app.data.appDb
-import io.legado.app.data.repository.SettingsRepository
 import io.legado.app.ui.config.backupConfig.BackupConfig
 import io.legado.app.ui.config.bookshelfConfig.BookshelfConfig
 import io.legado.app.ui.config.coverConfig.CoverConfig
@@ -22,16 +21,10 @@ import io.legado.app.utils.putPrefBoolean
 import io.legado.app.utils.putPrefInt
 import io.legado.app.utils.putPrefString
 import io.legado.app.utils.sysConfiguration
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.runBlocking
-import org.koin.java.KoinJavaComponent.get
 import splitties.init.appCtx
 
 @Suppress("MemberVisibilityCanBePrivate", "ConstPropertyName")
 object AppConfig {
-    private val settingsRepository: SettingsRepository by lazy {
-        get(SettingsRepository::class.java)
-    }
     val isCronet get() = DownloadCacheConfig.cronetEnable
     val useAntiAlias get() = OtherConfig.antiAlias
     val userAgent: String get() = DownloadCacheConfig.userAgent
@@ -195,20 +188,16 @@ object AppConfig {
         }
 
     var bookExportFileName: String?
-        get() = runBlocking {
-            settingsRepository.getString(PreferKey.bookExportFileName).first().ifEmpty { null }
-        }
+        get() = appCtx.getPrefString(PreferKey.bookExportFileName)
         set(value) {
-            runBlocking { DsSync.putString(PreferKey.bookExportFileName, value) }
+            appCtx.putPrefString(PreferKey.bookExportFileName, value)
         }
 
     // 保存 自定义导出章节模式 文件名js表达式
     var episodeExportFileName: String?
-        get() = runBlocking {
-            settingsRepository.getString(PreferKey.episodeExportFileName).first()
-        }
+        get() = appCtx.getPrefString(PreferKey.episodeExportFileName)
         set(value) {
-            runBlocking { DsSync.putString(PreferKey.episodeExportFileName, value) }
+            appCtx.putPrefString(PreferKey.episodeExportFileName, value)
         }
 
     var bookImportFileName: String?
@@ -414,15 +403,15 @@ object AppConfig {
         }
 
     var importKeepName: Boolean
-        get() = runBlocking { settingsRepository.getBoolean(PreferKey.importKeepName).first() }
-        set(value) { runBlocking { DsSync.putBoolean(PreferKey.importKeepName, value) } }
+        get() = appCtx.getPrefBoolean(PreferKey.importKeepName)
+        set(value) { appCtx.putPrefBoolean(PreferKey.importKeepName, value) }
     var importKeepGroup: Boolean
-        get() = runBlocking { settingsRepository.getBoolean(PreferKey.importKeepGroup).first() }
-        set(value) { runBlocking { DsSync.putBoolean(PreferKey.importKeepGroup, value) } }
+        get() = appCtx.getPrefBoolean(PreferKey.importKeepGroup)
+        set(value) { appCtx.putPrefBoolean(PreferKey.importKeepGroup, value) }
     var importKeepEnable: Boolean
-        get() = runBlocking { settingsRepository.getBoolean(PreferKey.importKeepEnable).first() }
+        get() = appCtx.getPrefBoolean(PreferKey.importKeepEnable)
         set(value) {
-            runBlocking { DsSync.putBoolean(PreferKey.importKeepEnable, value) }
+            appCtx.putPrefBoolean(PreferKey.importKeepEnable, value)
         }
 
     var previewImageByClick: Boolean

--- a/app/src/main/java/io/legado/app/help/config/AppConfig.kt
+++ b/app/src/main/java/io/legado/app/help/config/AppConfig.kt
@@ -1,10 +1,8 @@
 package io.legado.app.help.config
 
-import android.content.SharedPreferences
 import io.legado.app.BuildConfig
 import io.legado.app.constant.PreferKey
 import io.legado.app.data.appDb
-import io.legado.app.data.repository.ReadPreferences
 import io.legado.app.data.repository.SettingsRepository
 import io.legado.app.ui.config.backupConfig.BackupConfig
 import io.legado.app.ui.config.bookshelfConfig.BookshelfConfig
@@ -24,14 +22,13 @@ import io.legado.app.utils.putPrefBoolean
 import io.legado.app.utils.putPrefInt
 import io.legado.app.utils.putPrefString
 import io.legado.app.utils.sysConfiguration
-import io.legado.app.utils.toastOnUi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import org.koin.java.KoinJavaComponent.get
 import splitties.init.appCtx
 
 @Suppress("MemberVisibilityCanBePrivate", "ConstPropertyName")
-object AppConfig : SharedPreferences.OnSharedPreferenceChangeListener {
+object AppConfig {
     private val settingsRepository: SettingsRepository by lazy {
         get(SettingsRepository::class.java)
     }
@@ -39,18 +36,18 @@ object AppConfig : SharedPreferences.OnSharedPreferenceChangeListener {
     val useAntiAlias get() = OtherConfig.antiAlias
     val userAgent: String get() = DownloadCacheConfig.userAgent
 
-    var isEInkMode = appCtx.getPrefString("app_theme", "0") == "4"
-    var isTransparent = appCtx.getPrefString("app_theme", "0") == "13"
+    val isEInkMode get() = appCtx.getPrefString("app_theme", "0") == "4"
+    val isTransparent get() = appCtx.getPrefString("app_theme", "0") == "13"
     val customMode get() = ThemeConfig.customMode
-    var clickActionTL = appCtx.getPrefInt(PreferKey.clickActionTL, 2)
-    var clickActionTC = appCtx.getPrefInt(PreferKey.clickActionTC, 2)
-    var clickActionTR = appCtx.getPrefInt(PreferKey.clickActionTR, 1)
-    var clickActionML = appCtx.getPrefInt(PreferKey.clickActionML, 2)
-    var clickActionMC = appCtx.getPrefInt(PreferKey.clickActionMC, 0)
-    var clickActionMR = appCtx.getPrefInt(PreferKey.clickActionMR, 1)
-    var clickActionBL = appCtx.getPrefInt(PreferKey.clickActionBL, 2)
-    var clickActionBC = appCtx.getPrefInt(PreferKey.clickActionBC, 1)
-    var clickActionBR = appCtx.getPrefInt(PreferKey.clickActionBR, 1)
+    val clickActionTL get() = appCtx.getPrefInt(PreferKey.clickActionTL, 2)
+    val clickActionTC get() = appCtx.getPrefInt(PreferKey.clickActionTC, 2)
+    val clickActionTR get() = appCtx.getPrefInt(PreferKey.clickActionTR, 1)
+    val clickActionML get() = appCtx.getPrefInt(PreferKey.clickActionML, 2)
+    val clickActionMC get() = appCtx.getPrefInt(PreferKey.clickActionMC, 0)
+    val clickActionMR get() = appCtx.getPrefInt(PreferKey.clickActionMR, 1)
+    val clickActionBL get() = appCtx.getPrefInt(PreferKey.clickActionBL, 2)
+    val clickActionBC get() = appCtx.getPrefInt(PreferKey.clickActionBC, 1)
+    val clickActionBR get() = appCtx.getPrefInt(PreferKey.clickActionBR, 1)
 
     //    -1无操作 1下一页 2上一页 0显示菜单
     var mangaClickActionTL
@@ -97,105 +94,6 @@ object AppConfig : SharedPreferences.OnSharedPreferenceChangeListener {
     // -- lyc 版本特性 --
     val adaptSpecialStyle get() = ReadConfig.adaptSpecialStyle
     val useUnderline get() = ReadConfig.useUnderline
-
-    private var readBarStyleFollowPageValue =
-        appCtx.getPrefBoolean(PreferKey.readBarStyleFollowPage, false)
-    private var readBarStyleValue = appCtx.getPrefInt(PreferKey.readBarStyle, 0)
-
-    fun syncReadPreferences(preferences: ReadPreferences) {
-        ReadConfig.optimizeRender = preferences.optimizeRender
-        ReadConfig.adaptSpecialStyle = preferences.adaptSpecialStyle
-        ReadConfig.useUnderline = preferences.useUnderline
-        ReadConfig.chineseConverterType = preferences.chineseConverterType
-        clickActionTL = preferences.clickActionTL
-        clickActionTC = preferences.clickActionTC
-        clickActionTR = preferences.clickActionTR
-        clickActionML = preferences.clickActionML
-        clickActionMC = preferences.clickActionMC
-        clickActionMR = preferences.clickActionMR
-        clickActionBL = preferences.clickActionBL
-        clickActionBC = preferences.clickActionBC
-        clickActionBR = preferences.clickActionBR
-        ReadConfig.screenOrientation = preferences.screenOrientation
-        ReadConfig.noAnimScrollPage = preferences.noAnimScrollPage
-        ReadConfig.tocUiUseReplace = preferences.tocUiUseReplace
-        ReadConfig.tocCountWords = preferences.tocCountWords
-        ReadConfig.autoChangeSource = preferences.autoChangeSource
-        ReadConfig.clickImgWay = preferences.clickImgWay
-        ReadConfig.doubleHorizontalPage = preferences.doubleHorizontalPage
-        ReadConfig.progressBarBehavior = preferences.progressBarBehavior
-        ReadConfig.keyPageOnLongPress = preferences.keyPageOnLongPress
-        ReadConfig.volumeKeyPage = preferences.volumeKeyPage
-        ReadConfig.volumeKeyPageOnPlay = preferences.volumeKeyPageOnPlay
-        ReadConfig.mouseWheelPage = preferences.mouseWheelPage
-        ReadConfig.paddingDisplayCutouts = preferences.paddingDisplayCutouts
-        ReadConfig.pageTouchSlop = preferences.pageTouchSlop
-        ReadConfig.showReadTitleAddition = preferences.showReadTitleAddition
-        ReadConfig.titleBarMode = preferences.titleBarMode
-        ReadBookConfig.readMenuBlurAlpha = preferences.readMenuBlurAlpha
-        ReadBookConfig.readSliderMode = preferences.readSliderMode
-        readBarStyleFollowPageValue = preferences.readBarStyleFollowPage
-        readBarStyleValue = preferences.readBarStyle
-        ReadConfig.defaultSourceChangeAll = preferences.defaultSourceChangeAll
-        ReadConfig.sliderVibrator = preferences.sliderVibrator
-        ReadConfig.selectVibrator = preferences.selectVibrator
-        ReadBookConfig.brightnessVwPos = preferences.brightnessVwPos
-        ReadBookConfig.readBrightness = preferences.readBrightness
-    }
-
-    fun updateReadBarStyleCache(value: Int) {
-        readBarStyleValue = value.coerceIn(0, 2)
-    }
-
-    private fun syncReadPreferenceFromSharedPreferences(key: String?) {
-        when (key) {
-            PreferKey.readBarStyleFollowPage -> readBarStyleFollowPageValue =
-                appCtx.getPrefBoolean(PreferKey.readBarStyleFollowPage, false)
-            PreferKey.readBarStyle -> readBarStyleValue =
-                appCtx.getPrefInt(PreferKey.readBarStyle, 0)
-        }
-    }
-
-
-    override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences?, key: String?) {
-        syncReadPreferenceFromSharedPreferences(key)
-        when (key) {
-
-            PreferKey.clickActionTL -> clickActionTL =
-                appCtx.getPrefInt(PreferKey.clickActionTL, 2)
-
-            PreferKey.clickActionTC -> clickActionTC =
-                appCtx.getPrefInt(PreferKey.clickActionTC, 2)
-
-            PreferKey.clickActionTR -> clickActionTR =
-                appCtx.getPrefInt(PreferKey.clickActionTR, 1)
-
-            PreferKey.clickActionML -> clickActionML =
-                appCtx.getPrefInt(PreferKey.clickActionML, 2)
-
-            PreferKey.clickActionMC -> clickActionMC =
-                appCtx.getPrefInt(PreferKey.clickActionMC, 0)
-
-            PreferKey.clickActionMR -> clickActionMR =
-                appCtx.getPrefInt(PreferKey.clickActionMR, 1)
-
-            PreferKey.clickActionBL -> clickActionBL =
-                appCtx.getPrefInt(PreferKey.clickActionBL, 2)
-
-            PreferKey.clickActionBC -> clickActionBC =
-                appCtx.getPrefInt(PreferKey.clickActionBC, 1)
-
-            PreferKey.clickActionBR -> clickActionBR =
-                appCtx.getPrefInt(PreferKey.clickActionBR, 1)
-
-            PreferKey.readBodyToLh -> ReadBookConfig.readBodyToLh =
-                appCtx.getPrefBoolean(PreferKey.readBodyToLh, true)
-
-            PreferKey.useZhLayout -> ReadBookConfig.useZhLayout =
-                appCtx.getPrefBoolean(PreferKey.useZhLayout)
-
-        }
-    }
 
     var isNightTheme: Boolean
         get() = when (ThemeConfig.themeMode) {
@@ -649,17 +547,15 @@ object AppConfig : SharedPreferences.OnSharedPreferenceChangeListener {
         }
 
     var readBarStyleFollowPage: Boolean
-        get() = readBarStyleFollowPageValue
+        get() = appCtx.getPrefBoolean(PreferKey.readBarStyleFollowPage, false)
         set(value) {
-            readBarStyleFollowPageValue = value
             appCtx.putPrefBoolean(PreferKey.readBarStyleFollowPage, value)
         }
 
     var readBarStyle: Int
-        get() = readBarStyleValue
+        get() = appCtx.getPrefInt(PreferKey.readBarStyle, 0)
         set(value) {
-            readBarStyleValue = value.coerceIn(0, 2)
-            appCtx.putPrefInt(PreferKey.readBarStyle, readBarStyleValue)
+            appCtx.putPrefInt(PreferKey.readBarStyle, value.coerceIn(0, 2))
         }
 
     var sourceEditMaxLine: Int
@@ -679,20 +575,6 @@ object AppConfig : SharedPreferences.OnSharedPreferenceChangeListener {
         set(value) {
             appCtx.putPrefBoolean(PreferKey.brightnessVwPos, value)
         }
-
-    fun detectClickArea() {
-        if (clickActionTL * clickActionTC * clickActionTR
-            * clickActionML * clickActionMC * clickActionMR
-            * clickActionBL * clickActionBC * clickActionBR != 0
-        ) {
-            appCtx.putPrefInt(PreferKey.clickActionMC, 0)
-            appCtx.toastOnUi("当前没有配置菜单区域,自动恢复中间区域为菜单.")
-        }
-    }
-
-    fun detectMangaClickArea() {
-        ReadMangaConfig.detectMangaClickArea()
-    }
 
     var firebaseEnable: Boolean
         get() = OtherConfig.firebaseEnable

--- a/app/src/main/java/io/legado/app/help/config/AppConfigStore.kt
+++ b/app/src/main/java/io/legado/app/help/config/AppConfigStore.kt
@@ -19,6 +19,9 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import java.io.IOException
 
+import io.legado.app.utils.LogUtils
+import io.legado.app.utils.stackTraceStr
+
 /**
  * "settings" DataStore 的进程内内存快照层，设置读取的唯一同步入口。
  *
@@ -134,7 +137,16 @@ internal class PendingOverlayCore(
             launchWrite {
                 val result = runCatching { persist(key, value) }
                 synchronized(lock) {
-                    result.onSuccess { snapshot = it }
+                    result.onSuccess { 
+                        snapshot = it 
+                    }.onFailure { e ->
+                        val isOverridden = pending[key] !== write
+                        if (isOverridden) {
+                            LogUtils.e("AppConfigStore", "保存设置失败且已被新写入覆盖: key=$key, value=$value\n${e.stackTraceStr}")
+                        } else {
+                            LogUtils.e("AppConfigStore", "保存设置失败: key=$key, value=$value\n${e.stackTraceStr}")
+                        }
+                    }
                     // 同 key 已有更新的写入时不移除，继续由新条目覆盖
                     if (pending[key] === write) pending.remove(key)
                     rebuild()

--- a/app/src/main/java/io/legado/app/help/config/AppConfigStore.kt
+++ b/app/src/main/java/io/legado/app/help/config/AppConfigStore.kt
@@ -28,7 +28,7 @@ import io.legado.app.utils.stackTraceStr
  * 三个职责（不做其他事，防止长成 AppConfig 2.0）：
  * 1. snapshot：App.onCreate 首行同步预加载一次（同时触发 SharedPreferencesMigration），
  *    之后由常驻 collector 跟随 DataStore 变化回灌，保证外部写入（Restore 批量写等）可见；
- * 2. pending overlay：写入先进内存立即对读侧生效，异步串行落盘后移除，
+ * 2. pending overlay：写入先进内存立即对读侧生效，异步串行落盘、回灌确认后移除，
  *    保证"写后立即读"永远读到新值，collector 携带旧状态回灌也不会闪烁；
  * 3. observe：按 key 订阅变化，替代 SP OnSharedPreferenceChangeListener。
  *
@@ -61,6 +61,11 @@ object AppConfigStore {
             initial = initial,
             launchWrite = { DsSync.launchWrite(it) },
             persist = { key, value -> dataStore.edit { it.setPrefValue(key, value) } },
+            persistAll = { values ->
+                dataStore.edit { prefs ->
+                    values.forEach { (key, value) -> prefs.setPrefValue(key, value) }
+                }
+            },
         )
         core = newCore
         scope.launch {
@@ -95,6 +100,9 @@ object AppConfigStore {
     fun putStringSet(key: String, value: Set<String>) = requireCore().put(key, value)
     fun remove(key: String) = requireCore().put(key, null)
 
+    /** 批量写入（Restore 恢复备份等）：整批立即对读侧生效，单次 edit 落盘 */
+    fun putAll(values: Map<String, Any?>) = requireCore().putAll(values)
+
     // 订阅：替代 SP 监听器的统一入口，值不存在时发 null
     fun observeString(key: String): Flow<String?> = observe { it.compatDsString(key) }
     fun observeInt(key: String): Flow<Int?> = observe { it.compatDsInt(key) }
@@ -110,14 +118,17 @@ object AppConfigStore {
  * 快照 + pending overlay 的核心状态机，与 Android/DataStore 解耦以便 JVM 单测。
  *
  * 不变式：[preferencesFlow] = snapshot 叠加所有 pending 写入，pending 中的值永远优先。
- * pending 条目在对应落盘完成后移除；落盘返回的 Preferences 是该次 edit 后的完整状态，
- * 必然新于此前收到的任何回灌，因此落盘完成时直接采纳为 snapshot——即使 collector
- * 随后才处理一条落盘前的旧回灌，下一轮 collect 读到的也是最新状态，旧值不会驻留。
+ * snapshot 只由 collector 回灌（[onEmission]）推进，回灌按落盘提交顺序到达，因此单调不回退；
+ * pending 条目要等到回灌中该 key 的值已等于写入目标值时才移除——落盘完成后若先处理到
+ * 一条落盘前的旧回灌，该 key 仍被 overlay 保护，读值不会短暂回滚（回滚会让 observe
+ * 订阅方收到"新→旧→新"的幻影变更，如触发多余的 Activity recreate / WebDav refresh）。
+ * 落盘失败时移除对应 pending 实现回滚，读取回退到已落盘状态。
  */
 internal class PendingOverlayCore(
     initial: Preferences,
     private val launchWrite: (suspend () -> Unit) -> Unit,
     private val persist: suspend (key: String, value: Any?) -> Preferences,
+    private val persistAll: suspend (values: Map<String, Any?>) -> Preferences,
 ) {
 
     private val lock = Any()
@@ -135,21 +146,44 @@ internal class PendingOverlayCore(
             rebuild()
             // 在锁内提交写任务，保证落盘顺序与 pending 覆盖顺序一致
             launchWrite {
-                val result = runCatching { persist(key, value) }
-                synchronized(lock) {
-                    result.onSuccess { 
-                        snapshot = it 
-                    }.onFailure { e ->
-                        val isOverridden = pending[key] !== write
-                        if (isOverridden) {
-                            LogUtils.e("AppConfigStore", "保存设置失败且已被新写入覆盖: key=$key, value=$value\n${e.stackTraceStr}")
-                        } else {
+                // 成功时不动 snapshot/pending：等 collector 回灌到含新值的状态时（onEmission）
+                // 再移除 overlay，避免"落盘完成后才处理到旧回灌"导致读值短暂回滚
+                runCatching { persist(key, value) }.onFailure { e ->
+                    synchronized(lock) {
+                        if (pending[key] === write) {
+                            // 失败回滚：移除 overlay，读取回退到已落盘状态
+                            pending.remove(key)
+                            rebuild()
                             LogUtils.e("AppConfigStore", "保存设置失败: key=$key, value=$value\n${e.stackTraceStr}")
+                        } else {
+                            // 同 key 已有更新的写入，继续由新条目覆盖
+                            LogUtils.e("AppConfigStore", "保存设置失败且已被新写入覆盖: key=$key, value=$value\n${e.stackTraceStr}")
                         }
                     }
-                    // 同 key 已有更新的写入时不移除，继续由新条目覆盖
-                    if (pending[key] === write) pending.remove(key)
-                    rebuild()
+                }
+            }
+        }
+    }
+
+    fun putAll(values: Map<String, Any?>) {
+        if (values.isEmpty()) return
+        synchronized(lock) {
+            val writes = values.mapValues { PendingWrite(it.value) }
+            pending.putAll(writes)
+            rebuild()
+            launchWrite {
+                runCatching { persistAll(values) }.onFailure { e ->
+                    synchronized(lock) {
+                        var removed = false
+                        writes.forEach { (key, write) ->
+                            if (pending[key] === write) {
+                                pending.remove(key)
+                                removed = true
+                            }
+                        }
+                        if (removed) rebuild()
+                        LogUtils.e("AppConfigStore", "批量保存设置失败: keys=${values.keys}\n${e.stackTraceStr}")
+                    }
                 }
             }
         }
@@ -158,6 +192,9 @@ internal class PendingOverlayCore(
     fun onEmission(prefs: Preferences) {
         synchronized(lock) {
             snapshot = prefs
+            // 回灌已包含某个 pending 写入的目标值时，说明该写入已落盘且对 collector 可见，
+            // 此时移除 overlay 才不会被更早的旧回灌回滚
+            pending.entries.removeAll { (key, write) -> prefs.rawPrefValue(key) == write.value }
             rebuild()
         }
     }

--- a/app/src/main/java/io/legado/app/help/config/AppConfigStore.kt
+++ b/app/src/main/java/io/legado/app/help/config/AppConfigStore.kt
@@ -132,9 +132,9 @@ internal class PendingOverlayCore(
             rebuild()
             // 在锁内提交写任务，保证落盘顺序与 pending 覆盖顺序一致
             launchWrite {
-                val result = persist(key, value)
+                val result = runCatching { persist(key, value) }
                 synchronized(lock) {
-                    snapshot = result
+                    result.onSuccess { snapshot = it }
                     // 同 key 已有更新的写入时不移除，继续由新条目覆盖
                     if (pending[key] === write) pending.remove(key)
                     rebuild()

--- a/app/src/main/java/io/legado/app/help/config/AppConfigStore.kt
+++ b/app/src/main/java/io/legado/app/help/config/AppConfigStore.kt
@@ -42,8 +42,6 @@ object AppConfigStore {
     private var core: PendingOverlayCore? = null
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
-    val isInitialized: Boolean get() = core != null
-
     /**
      * 在 App.onCreate 首行调用，先于一切设置读取（主题初始化等）。
      * runBlocking 首读会触发 DataStore 迁移，与旧版首个 PrefDelegate 构造时的行为一致，
@@ -59,7 +57,7 @@ object AppConfigStore {
         }
         val newCore = PendingOverlayCore(
             initial = initial,
-            launchWrite = { DsSync.launchWrite(it) },
+            launchWrite = { SettingsWriter.launchWrite(it) },
             persist = { key, value -> dataStore.edit { it.setPrefValue(key, value) } },
             persistAll = { values ->
                 dataStore.edit { prefs ->

--- a/app/src/main/java/io/legado/app/help/config/AppConfigStore.kt
+++ b/app/src/main/java/io/legado/app/help/config/AppConfigStore.kt
@@ -1,0 +1,162 @@
+package io.legado.app.help.config
+
+import android.content.Context
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
+import io.legado.app.data.repository.dataStore
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import java.io.IOException
+
+/**
+ * "settings" DataStore 的进程内内存快照层，设置读取的唯一同步入口。
+ *
+ * 三个职责（不做其他事，防止长成 AppConfig 2.0）：
+ * 1. snapshot：App.onCreate 首行同步预加载一次（同时触发 SharedPreferencesMigration），
+ *    之后由常驻 collector 跟随 DataStore 变化回灌，保证外部写入（Restore 批量写等）可见；
+ * 2. pending overlay：写入先进内存立即对读侧生效，异步串行落盘后移除，
+ *    保证"写后立即读"永远读到新值，collector 携带旧状态回灌也不会闪烁；
+ * 3. observe：按 key 订阅变化，替代 SP OnSharedPreferenceChangeListener。
+ *
+ * 约束：读 API 是纯内存查找（主线程零 IO），但 onCreate 的预加载耗时与 settings 文件
+ * 大小成正比——大 value（长 JSON、图片路径列表等）不得写进 "settings" DataStore，
+ * 应走各自的文件级配置。
+ */
+object AppConfigStore {
+
+    @Volatile
+    private var core: PendingOverlayCore? = null
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    val isInitialized: Boolean get() = core != null
+
+    /**
+     * 在 App.onCreate 首行调用，先于一切设置读取（主题初始化等）。
+     * runBlocking 首读会触发 DataStore 迁移，与旧版首个 PrefDelegate 构造时的行为一致，
+     * 只是显式提前且全程只做一次。
+     */
+    fun init(context: Context) {
+        if (core != null) return
+        val dataStore = context.applicationContext.dataStore
+        val initial = runBlocking {
+            dataStore.data
+                .catch { if (it is IOException) emit(emptyPreferences()) else throw it }
+                .first()
+        }
+        val newCore = PendingOverlayCore(
+            initial = initial,
+            launchWrite = { DsSync.launchWrite(it) },
+            persist = { key, value -> dataStore.edit { it.setPrefValue(key, value) } },
+        )
+        core = newCore
+        scope.launch {
+            dataStore.data
+                .catch { if (it is IOException) emit(emptyPreferences()) else throw it }
+                .collect { newCore.onEmission(it) }
+        }
+    }
+
+    private fun requireCore(): PendingOverlayCore =
+        checkNotNull(core) { "AppConfigStore 未初始化，应在 App.onCreate 首行调用 init()" }
+
+    /** 当前生效的设置快照（DataStore 落盘状态 + 未落盘写入叠加） */
+    val preferences: Preferences get() = requireCore().preferencesFlow.value
+
+    val preferencesFlow: StateFlow<Preferences> get() = requireCore().preferencesFlow
+
+    // 读取：key 不存在时返回 null，由调用方（过渡期的门面）决定回退行为
+    fun getString(key: String): String? = preferences.compatDsString(key)
+    fun getInt(key: String): Int? = preferences.compatDsInt(key)
+    fun getBoolean(key: String): Boolean? = preferences.compatDsBoolean(key)
+    fun getLong(key: String): Long? = preferences.compatDsLong(key)
+    fun getFloat(key: String): Float? = preferences.compatDsFloat(key)
+    fun getStringSet(key: String): Set<String>? = preferences.compatDsStringSet(key)
+
+    // 写入：立即对读侧生效，异步串行落盘；value 为 null 表示移除
+    fun putString(key: String, value: String?) = requireCore().put(key, value)
+    fun putInt(key: String, value: Int) = requireCore().put(key, value)
+    fun putBoolean(key: String, value: Boolean) = requireCore().put(key, value)
+    fun putLong(key: String, value: Long) = requireCore().put(key, value)
+    fun putFloat(key: String, value: Float) = requireCore().put(key, value)
+    fun putStringSet(key: String, value: Set<String>) = requireCore().put(key, value)
+    fun remove(key: String) = requireCore().put(key, null)
+
+    // 订阅：替代 SP 监听器的统一入口，值不存在时发 null
+    fun observeString(key: String): Flow<String?> = observe { it.compatDsString(key) }
+    fun observeInt(key: String): Flow<Int?> = observe { it.compatDsInt(key) }
+    fun observeBoolean(key: String): Flow<Boolean?> = observe { it.compatDsBoolean(key) }
+    fun observeLong(key: String): Flow<Long?> = observe { it.compatDsLong(key) }
+    fun observeFloat(key: String): Flow<Float?> = observe { it.compatDsFloat(key) }
+
+    private inline fun <T> observe(crossinline read: (Preferences) -> T?): Flow<T?> =
+        preferencesFlow.map { read(it) }.distinctUntilChanged()
+}
+
+/**
+ * 快照 + pending overlay 的核心状态机，与 Android/DataStore 解耦以便 JVM 单测。
+ *
+ * 不变式：[preferencesFlow] = snapshot 叠加所有 pending 写入，pending 中的值永远优先。
+ * pending 条目在对应落盘完成后移除；落盘返回的 Preferences 是该次 edit 后的完整状态，
+ * 必然新于此前收到的任何回灌，因此落盘完成时直接采纳为 snapshot——即使 collector
+ * 随后才处理一条落盘前的旧回灌，下一轮 collect 读到的也是最新状态，旧值不会驻留。
+ */
+internal class PendingOverlayCore(
+    initial: Preferences,
+    private val launchWrite: (suspend () -> Unit) -> Unit,
+    private val persist: suspend (key: String, value: Any?) -> Preferences,
+) {
+
+    private val lock = Any()
+    private var snapshot: Preferences = initial
+    private val pending = LinkedHashMap<String, PendingWrite>()
+    private val _preferences = MutableStateFlow(initial)
+    val preferencesFlow: StateFlow<Preferences> get() = _preferences
+
+    private class PendingWrite(val value: Any?)
+
+    fun put(key: String, value: Any?) {
+        synchronized(lock) {
+            val write = PendingWrite(value)
+            pending[key] = write
+            rebuild()
+            // 在锁内提交写任务，保证落盘顺序与 pending 覆盖顺序一致
+            launchWrite {
+                val result = persist(key, value)
+                synchronized(lock) {
+                    snapshot = result
+                    // 同 key 已有更新的写入时不移除，继续由新条目覆盖
+                    if (pending[key] === write) pending.remove(key)
+                    rebuild()
+                }
+            }
+        }
+    }
+
+    fun onEmission(prefs: Preferences) {
+        synchronized(lock) {
+            snapshot = prefs
+            rebuild()
+        }
+    }
+
+    private fun rebuild() {
+        if (pending.isEmpty()) {
+            _preferences.value = snapshot
+            return
+        }
+        val prefs = snapshot.toMutablePreferences()
+        pending.forEach { (key, write) -> prefs.setPrefValue(key, write.value) }
+        _preferences.value = prefs.toPreferences()
+    }
+}

--- a/app/src/main/java/io/legado/app/help/config/DsSync.kt
+++ b/app/src/main/java/io/legado/app/help/config/DsSync.kt
@@ -1,12 +1,5 @@
 package io.legado.app.help.config
 
-import androidx.datastore.preferences.core.booleanPreferencesKey
-import androidx.datastore.preferences.core.edit
-import androidx.datastore.preferences.core.floatPreferencesKey
-import androidx.datastore.preferences.core.intPreferencesKey
-import androidx.datastore.preferences.core.longPreferencesKey
-import androidx.datastore.preferences.core.stringPreferencesKey
-import io.legado.app.data.repository.dataStore
 import io.legado.app.utils.LogUtils
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -15,9 +8,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
-import splitties.init.appCtx
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.measureTime
@@ -68,28 +59,5 @@ object DsSync {
                 delay(50)
             }
         }
-    }
-
-    suspend fun putString(key: String, value: String?) {
-        appCtx.dataStore.edit { prefs ->
-            val dsKey = stringPreferencesKey(key)
-            if (value == null) prefs.remove(dsKey) else prefs[dsKey] = value
-        }
-    }
-
-    suspend fun putInt(key: String, value: Int) {
-        appCtx.dataStore.edit { it[intPreferencesKey(key)] = value }
-    }
-
-    suspend fun putBoolean(key: String, value: Boolean) {
-        appCtx.dataStore.edit { it[booleanPreferencesKey(key)] = value }
-    }
-
-    suspend fun putLong(key: String, value: Long) {
-        appCtx.dataStore.edit { it[longPreferencesKey(key)] = value }
-    }
-
-    suspend fun putFloat(key: String, value: Float) {
-        appCtx.dataStore.edit { it[floatPreferencesKey(key)] = value }
     }
 }

--- a/app/src/main/java/io/legado/app/help/config/DsSync.kt
+++ b/app/src/main/java/io/legado/app/help/config/DsSync.kt
@@ -7,6 +7,12 @@ import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import io.legado.app.data.repository.dataStore
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 import splitties.init.appCtx
 
 /**
@@ -16,6 +22,20 @@ import splitties.init.appCtx
  * 保证两边数据一致，避免 DataStore 迁移/读取时出现值缺失。
  */
 object DsSync {
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private val writeDispatcher = Dispatchers.IO.limitedParallelism(1)
+
+    /**
+     * 串行写队列：所有经 [AppConfigStore] 的写入按提交顺序落盘。
+     * 写入失败仅吞掉异常（与旧 PrefDelegate 行为一致），此时值仍在内存快照中，重启后丢失。
+     */
+    fun launchWrite(block: suspend () -> Unit): Job =
+        scope.launch(writeDispatcher) {
+            runCatching { block() }
+        }
 
     suspend fun putString(key: String, value: String?) {
         appCtx.dataStore.edit { prefs ->

--- a/app/src/main/java/io/legado/app/help/config/DsSync.kt
+++ b/app/src/main/java/io/legado/app/help/config/DsSync.kt
@@ -63,12 +63,10 @@ object DsSync {
      * 用于 restart 等必须确保"写入已持久化"的场景。
      */
     suspend fun awaitPendingWrites(timeoutMs: Long = 3000) {
-        val startTime = System.currentTimeMillis()
-        while (pendingCount.get() > 0) {
-            if (System.currentTimeMillis() - startTime > timeoutMs) {
-                break
+        withTimeoutOrNull(timeoutMs) {
+            while (pendingCount.get() > 0) {
+                delay(50)
             }
-            delay(50)
         }
     }
 

--- a/app/src/main/java/io/legado/app/help/config/DsSync.kt
+++ b/app/src/main/java/io/legado/app/help/config/DsSync.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
@@ -62,10 +63,12 @@ object DsSync {
      * 用于 restart 等必须确保"写入已持久化"的场景。
      */
     suspend fun awaitPendingWrites(timeoutMs: Long = 3000) {
-        withContext(writeDispatcher) {
-            withTimeoutOrNull(timeoutMs) {
-                // 在串行 dispatcher 上执行一个空任务：排在前面的写入全部完成后才会轮到它
+        val startTime = System.currentTimeMillis()
+        while (pendingCount.get() > 0) {
+            if (System.currentTimeMillis() - startTime > timeoutMs) {
+                break
             }
+            delay(50)
         }
     }
 

--- a/app/src/main/java/io/legado/app/help/config/DsSync.kt
+++ b/app/src/main/java/io/legado/app/help/config/DsSync.kt
@@ -7,19 +7,22 @@ import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import io.legado.app.data.repository.dataStore
+import io.legado.app.utils.LogUtils
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import splitties.init.appCtx
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.measureTime
 
 /**
- * DataStore 写入辅助对象。
- *
- * 让 [io.legado.app.ui.config.PrefDelegate] 在写入 SP 的同时同步写入 DataStore，
- * 保证两边数据一致，避免 DataStore 迁移/读取时出现值缺失。
+ * DataStore 写入序列化队列，所有经 [AppConfigStore] 的异步写入按提交顺序串行落盘。
  */
 object DsSync {
 
@@ -28,14 +31,43 @@ object DsSync {
     @OptIn(ExperimentalCoroutinesApi::class)
     private val writeDispatcher = Dispatchers.IO.limitedParallelism(1)
 
+    private val pendingCount = AtomicInteger(0)
+
+    /** 当前排队的写入任务数（含正在执行的那一个）。*/
+    val pendingWriteCount: Int get() = pendingCount.get()
+
     /**
      * 串行写队列：所有经 [AppConfigStore] 的写入按提交顺序落盘。
      * 写入失败仅吞掉异常（与旧 PrefDelegate 行为一致），此时值仍在内存快照中，重启后丢失。
      */
-    fun launchWrite(block: suspend () -> Unit): Job =
-        scope.launch(writeDispatcher) {
-            runCatching { block() }
+    fun launchWrite(block: suspend () -> Unit): Job {
+        pendingCount.incrementAndGet()
+        return scope.launch(writeDispatcher) {
+            try {
+                val elapsed = measureTime { runCatching { block() } }
+                if (elapsed > 500.milliseconds) {
+                    LogUtils.d(
+                        "DsSync",
+                        "单次 edit 耗时 ${elapsed.inWholeMilliseconds}ms, 队列剩余 ${pendingCount.get() - 1}"
+                    )
+                }
+            } finally {
+                pendingCount.decrementAndGet()
+            }
         }
+    }
+
+    /**
+     * 等待所有排队的写入落盘完成（最长等待 [timeoutMs] 毫秒）。
+     * 用于 restart 等必须确保"写入已持久化"的场景。
+     */
+    suspend fun awaitPendingWrites(timeoutMs: Long = 3000) {
+        withContext(writeDispatcher) {
+            withTimeoutOrNull(timeoutMs) {
+                // 在串行 dispatcher 上执行一个空任务：排在前面的写入全部完成后才会轮到它
+            }
+        }
+    }
 
     suspend fun putString(key: String, value: String?) {
         appCtx.dataStore.edit { prefs ->

--- a/app/src/main/java/io/legado/app/help/config/LocalConfig.kt
+++ b/app/src/main/java/io/legado/app/help/config/LocalConfig.kt
@@ -69,6 +69,13 @@ by appCtx.getSharedPreferences("local", Context.MODE_PRIVATE) {
             putBoolean("navExtended", value)
         }
 
+    /** 旧版语言偏好是否已迁移到 AppCompat per-app locales（App.onCreate 一次性迁移） */
+    var appLocaleMigrated: Boolean
+        get() = getBoolean("appLocaleMigrated")
+        set(value) {
+            putBoolean("appLocaleMigrated", value)
+        }
+
     val readHelpVersionIsLast: Boolean
         get() = isLastVersion(1, "readHelpVersion", "firstRead")
 

--- a/app/src/main/java/io/legado/app/help/config/PreferencesDsCompat.kt
+++ b/app/src/main/java/io/legado/app/help/config/PreferencesDsCompat.kt
@@ -23,7 +23,7 @@ import androidx.datastore.preferences.core.stringSetPreferencesKey
  * 取 key 对应的原始存储值（不做类型断言）。
  * 声明为 Any? 避免泛型擦除后的 checkcast，存储类型不匹配也不会抛 ClassCastException。
  */
-fun Preferences.rawPrefValue(key: String): Any? = this[stringPreferencesKey(key)]
+fun Preferences.rawPrefValue(key: String): Any? = asMap()[stringPreferencesKey(key)]
 
 fun Preferences.compatDsString(key: String): String? = rawPrefValue(key) as? String
 

--- a/app/src/main/java/io/legado/app/help/config/PreferencesDsCompat.kt
+++ b/app/src/main/java/io/legado/app/help/config/PreferencesDsCompat.kt
@@ -21,9 +21,11 @@ import androidx.datastore.preferences.core.stringSetPreferencesKey
 
 /**
  * 取 key 对应的原始存储值（不做类型断言）。
- * 声明为 Any? 避免泛型擦除后的 checkcast，存储类型不匹配也不会抛 ClassCastException。
+ * Key 按 name 判等，用 string 类型的 key 即可取到该 name 下任意类型的原始值；
+ * 返回位置声明为 Any? 使编译器不插入 checkcast，存储类型不匹配也不会抛 ClassCastException。
+ * 不可用 asMap() 实现：datastore 的 asMap() 每次调用都会防御性复制整个 map，读是热路径。
  */
-fun Preferences.rawPrefValue(key: String): Any? = asMap()[stringPreferencesKey(key)]
+fun Preferences.rawPrefValue(key: String): Any? = this[stringPreferencesKey(key)]
 
 fun Preferences.compatDsString(key: String): String? = when (val raw = rawPrefValue(key)) {
     is String -> raw

--- a/app/src/main/java/io/legado/app/help/config/PreferencesDsCompat.kt
+++ b/app/src/main/java/io/legado/app/help/config/PreferencesDsCompat.kt
@@ -1,0 +1,77 @@
+package io.legado.app.help.config
+
+import androidx.datastore.preferences.core.MutablePreferences
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.floatPreferencesKey
+import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.core.longPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.core.stringSetPreferencesKey
+
+/**
+ * DataStore 值的类型兼容读写。
+ *
+ * 历史数据（SP 迁移、旧版本写入）里同一 key 的存储类型可能与读取类型不一致：
+ * int 存成 string（"1"）、long 存成 int 等。这里统一做"按实际存储类型取值，再转换到目标类型"。
+ *
+ * 注意：依赖 [Preferences.Key] 的 equals/hashCode 只比较 name（datastore 既有行为，
+ * 也是同名不同类型 key 会互相覆盖的原因），因此用任意类型的 key 都能取到该 name 下的原始值。
+ */
+
+/**
+ * 取 key 对应的原始存储值（不做类型断言）。
+ * 声明为 Any? 避免泛型擦除后的 checkcast，存储类型不匹配也不会抛 ClassCastException。
+ */
+fun Preferences.rawPrefValue(key: String): Any? = this[stringPreferencesKey(key)]
+
+fun Preferences.compatDsString(key: String): String? = rawPrefValue(key) as? String
+
+fun Preferences.compatDsInt(key: String): Int? = when (val raw = rawPrefValue(key)) {
+    is Int -> raw
+    is String -> raw.toIntOrNull()
+    else -> null
+}
+
+fun Preferences.compatDsBoolean(key: String): Boolean? = when (val raw = rawPrefValue(key)) {
+    is Boolean -> raw
+    is String -> raw.toBooleanStrictOrNull()
+    else -> null
+}
+
+fun Preferences.compatDsLong(key: String): Long? = when (val raw = rawPrefValue(key)) {
+    is Long -> raw
+    is Int -> raw.toLong()
+    is String -> raw.toLongOrNull()
+    else -> null
+}
+
+fun Preferences.compatDsFloat(key: String): Float? = when (val raw = rawPrefValue(key)) {
+    is Float -> raw
+    is Int -> raw.toFloat()
+    is String -> raw.toFloatOrNull()
+    else -> null
+}
+
+fun Preferences.compatDsStringSet(key: String): Set<String>? = when (val raw = rawPrefValue(key)) {
+    is Set<*> -> @Suppress("UNCHECKED_CAST") (raw as Set<String>)
+    else -> null
+}
+
+/**
+ * 按 value 的运行时类型写入对应类型的 key；value 为 null 表示移除。
+ * 由于 Key 按 name 判等，写入会覆盖同名的旧类型条目，移除一次即可清掉任意类型的条目。
+ */
+fun MutablePreferences.setPrefValue(key: String, value: Any?) {
+    when (value) {
+        null -> remove(stringPreferencesKey(key))
+        is String -> this[stringPreferencesKey(key)] = value
+        is Int -> this[intPreferencesKey(key)] = value
+        is Boolean -> this[booleanPreferencesKey(key)] = value
+        is Long -> this[longPreferencesKey(key)] = value
+        is Float -> this[floatPreferencesKey(key)] = value
+        is Set<*> -> @Suppress("UNCHECKED_CAST") {
+            this[stringSetPreferencesKey(key)] = value as Set<String>
+        }
+    }
+}

--- a/app/src/main/java/io/legado/app/help/config/PreferencesDsCompat.kt
+++ b/app/src/main/java/io/legado/app/help/config/PreferencesDsCompat.kt
@@ -25,30 +25,41 @@ import androidx.datastore.preferences.core.stringSetPreferencesKey
  */
 fun Preferences.rawPrefValue(key: String): Any? = asMap()[stringPreferencesKey(key)]
 
-fun Preferences.compatDsString(key: String): String? = rawPrefValue(key) as? String
+fun Preferences.compatDsString(key: String): String? = when (val raw = rawPrefValue(key)) {
+    is String -> raw
+    is Number, is Boolean -> raw.toString()
+    else -> null
+}
 
 fun Preferences.compatDsInt(key: String): Int? = when (val raw = rawPrefValue(key)) {
-    is Int -> raw
+    is Number -> raw.toInt()
     is String -> raw.toIntOrNull()
     else -> null
 }
 
 fun Preferences.compatDsBoolean(key: String): Boolean? = when (val raw = rawPrefValue(key)) {
     is Boolean -> raw
-    is String -> raw.toBooleanStrictOrNull()
+    is String -> raw.toBooleanStrictOrNull() ?: when (raw) {
+        "1" -> true
+        "0" -> false
+        else -> null
+    }
+    is Number -> when (raw.toInt()) {
+        1 -> true
+        0 -> false
+        else -> null
+    }
     else -> null
 }
 
 fun Preferences.compatDsLong(key: String): Long? = when (val raw = rawPrefValue(key)) {
-    is Long -> raw
-    is Int -> raw.toLong()
+    is Number -> raw.toLong()
     is String -> raw.toLongOrNull()
     else -> null
 }
 
 fun Preferences.compatDsFloat(key: String): Float? = when (val raw = rawPrefValue(key)) {
-    is Float -> raw
-    is Int -> raw.toFloat()
+    is Number -> raw.toFloat()
     is String -> raw.toFloatOrNull()
     else -> null
 }

--- a/app/src/main/java/io/legado/app/help/config/SettingsWriter.kt
+++ b/app/src/main/java/io/legado/app/help/config/SettingsWriter.kt
@@ -16,7 +16,7 @@ import kotlin.time.measureTime
 /**
  * DataStore 写入序列化队列，所有经 [AppConfigStore] 的异步写入按提交顺序串行落盘。
  */
-object DsSync {
+object SettingsWriter {
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
@@ -39,7 +39,7 @@ object DsSync {
                 val elapsed = measureTime { runCatching { block() } }
                 if (elapsed > 500.milliseconds) {
                     LogUtils.d(
-                        "DsSync",
+                        "SettingsWriter",
                         "单次 edit 耗时 ${elapsed.inWholeMilliseconds}ms, 队列剩余 ${pendingCount.get() - 1}"
                     )
                 }

--- a/app/src/main/java/io/legado/app/help/storage/Restore.kt
+++ b/app/src/main/java/io/legado/app/help/storage/Restore.kt
@@ -38,7 +38,7 @@ import io.legado.app.help.book.isLocal
 import io.legado.app.help.book.upType
 import io.legado.app.help.config.AppConfigStore
 import io.legado.app.help.config.LocalConfig
-import io.legado.app.help.config.DsSync
+import io.legado.app.help.config.SettingsWriter
 import io.legado.app.help.config.ThemeConfigStore
 import io.legado.app.help.config.ReadBookConfig
 import io.legado.app.ui.config.otherConfig.OtherConfig
@@ -406,7 +406,7 @@ object Restore : KoinComponent {
         // 经快照层批量恢复：立即对读侧生效（onRestoreFinish 的读取不再依赖回灌时机），单次原子 edit 落盘
         AppConfigStore.putAll(finalMap)
         // 恢复完成提示前等待落盘，dataStore.edit 返回即持久化完成
-        DsSync.awaitPendingWrites()
+        SettingsWriter.awaitPendingWrites()
     }
 
     private fun readXmlToMap(file: File): Map<String, Any?> {

--- a/app/src/main/java/io/legado/app/help/storage/Restore.kt
+++ b/app/src/main/java/io/legado/app/help/storage/Restore.kt
@@ -3,7 +3,9 @@ package io.legado.app.help.storage
 import android.content.Context
 import android.database.sqlite.SQLiteConstraintException
 import android.net.Uri
+import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.content.edit
+import androidx.core.os.LocaleListCompat
 import androidx.documentfile.provider.DocumentFile
 import io.legado.app.BuildConfig
 import io.legado.app.R
@@ -40,6 +42,7 @@ import io.legado.app.help.book.upType
 import io.legado.app.help.config.LocalConfig
 import io.legado.app.help.config.ThemeConfigStore
 import io.legado.app.help.config.ReadBookConfig
+import io.legado.app.ui.config.otherConfig.OtherConfig
 import io.legado.app.model.BookCover
 import io.legado.app.model.localBook.LocalBook
 import io.legado.app.utils.ACache
@@ -335,6 +338,14 @@ object Restore : KoinComponent {
         appCtx.toastOnUi(R.string.restore_success)
         withContext(Main) {
             delay(100)
+            val language = OtherConfig.language
+            val localeList = when (language) {
+                "zh" -> LocaleListCompat.create(java.util.Locale.SIMPLIFIED_CHINESE)
+                "tw" -> LocaleListCompat.create(java.util.Locale.TRADITIONAL_CHINESE)
+                "en" -> LocaleListCompat.create(java.util.Locale.ENGLISH)
+                else -> LocaleListCompat.getEmptyLocaleList()
+            }
+            AppCompatDelegate.setApplicationLocales(localeList)
             if (!BuildConfig.DEBUG) {
                 LauncherIconHelp.changeIcon(appCtx.getPrefString(PreferKey.launcherIcon))
             }

--- a/app/src/main/java/io/legado/app/help/storage/Restore.kt
+++ b/app/src/main/java/io/legado/app/help/storage/Restore.kt
@@ -5,7 +5,6 @@ import android.database.sqlite.SQLiteConstraintException
 import android.net.Uri
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.content.edit
-import androidx.core.os.LocaleListCompat
 import androidx.documentfile.provider.DocumentFile
 import io.legado.app.BuildConfig
 import io.legado.app.R
@@ -34,15 +33,16 @@ import io.legado.app.data.entities.TxtTocRule
 import io.legado.app.data.entities.readRecord.ReadRecord
 import io.legado.app.data.entities.readRecord.ReadRecordDetail
 import io.legado.app.data.entities.readRecord.ReadRecordSession
-import io.legado.app.data.repository.SettingsRepository
 import io.legado.app.help.DirectLinkUpload
 import io.legado.app.help.LauncherIconHelp
 import io.legado.app.help.book.isLocal
 import io.legado.app.help.book.upType
+import io.legado.app.help.config.AppConfigStore
 import io.legado.app.help.config.LocalConfig
 import io.legado.app.help.config.ThemeConfigStore
 import io.legado.app.help.config.ReadBookConfig
 import io.legado.app.ui.config.otherConfig.OtherConfig
+import io.legado.app.ui.config.otherConfig.appLocaleListFor
 import io.legado.app.model.BookCover
 import io.legado.app.model.localBook.LocalBook
 import io.legado.app.utils.ACache
@@ -61,7 +61,6 @@ import kotlinx.coroutines.Dispatchers.Main
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 import org.koin.core.component.KoinComponent
-import org.koin.core.component.inject
 import org.xmlpull.v1.XmlPullParser
 import org.xmlpull.v1.XmlPullParserFactory
 import splitties.init.appCtx
@@ -73,7 +72,6 @@ import java.io.FileInputStream
  */
 object Restore : KoinComponent {
 
-    private val settingsRepository: SettingsRepository by inject()
     private const val TAG = "Restore"
 
     suspend fun restore(context: Context, uri: Uri) {
@@ -338,14 +336,7 @@ object Restore : KoinComponent {
         appCtx.toastOnUi(R.string.restore_success)
         withContext(Main) {
             delay(100)
-            val language = OtherConfig.language
-            val localeList = when (language) {
-                "zh" -> LocaleListCompat.create(java.util.Locale.SIMPLIFIED_CHINESE)
-                "tw" -> LocaleListCompat.create(java.util.Locale.TRADITIONAL_CHINESE)
-                "en" -> LocaleListCompat.create(java.util.Locale.ENGLISH)
-                else -> LocaleListCompat.getEmptyLocaleList()
-            }
-            AppCompatDelegate.setApplicationLocales(localeList)
+            AppCompatDelegate.setApplicationLocales(appLocaleListFor(OtherConfig.language))
             if (!BuildConfig.DEBUG) {
                 LauncherIconHelp.changeIcon(appCtx.getPrefString(PreferKey.launcherIcon))
             }
@@ -466,8 +457,8 @@ object Restore : KoinComponent {
                 }
             }
         }
-        // 同步恢复到 DataStore
-        settingsRepository.batchPutFromMap(finalMap)
+        // 经快照层批量恢复：立即对读侧生效（onRestoreFinish 的读取不再依赖回灌时机），异步单次 edit 落盘
+        AppConfigStore.putAll(finalMap)
     }
 
     private fun readXmlToMap(file: File): Map<String, Any?> {

--- a/app/src/main/java/io/legado/app/help/storage/Restore.kt
+++ b/app/src/main/java/io/legado/app/help/storage/Restore.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.database.sqlite.SQLiteConstraintException
 import android.net.Uri
 import androidx.appcompat.app.AppCompatDelegate
-import androidx.core.content.edit
 import androidx.documentfile.provider.DocumentFile
 import io.legado.app.BuildConfig
 import io.legado.app.R
@@ -39,6 +38,7 @@ import io.legado.app.help.book.isLocal
 import io.legado.app.help.book.upType
 import io.legado.app.help.config.AppConfigStore
 import io.legado.app.help.config.LocalConfig
+import io.legado.app.help.config.DsSync
 import io.legado.app.help.config.ThemeConfigStore
 import io.legado.app.help.config.ReadBookConfig
 import io.legado.app.ui.config.otherConfig.OtherConfig
@@ -50,7 +50,6 @@ import io.legado.app.utils.FileUtils
 import io.legado.app.utils.GSON
 import io.legado.app.utils.LogUtils
 import io.legado.app.utils.compress.ZipUtils
-import io.legado.app.utils.defaultSharedPreferences
 import io.legado.app.utils.fromJsonArray
 import io.legado.app.utils.getPrefString
 import io.legado.app.utils.isContentScheme
@@ -397,68 +396,17 @@ object Restore : KoinComponent {
     }
 
     private suspend fun applyConfigMap(map: Map<String, Any?>, aes: BackupAES) {
-        val finalMap = mutableMapOf<String, Any>()
-        val legacyBookInfoBackground = map[PreferKey.bookInfoBackgroundBlur] as? String
-        val restoreNetworkCoverBackground =
-            legacyBookInfoBackground != null &&
-                    PreferKey.bookInfoNetworkCoverBackground !in map &&
-                    BackupConfig.keyIsNotIgnore(PreferKey.bookInfoBackgroundBlur) &&
-                    BackupConfig.keyIsNotIgnore(PreferKey.bookInfoNetworkCoverBackground)
-        val restoreDefaultCoverBackground =
-            legacyBookInfoBackground != null &&
-                    PreferKey.bookInfoDefaultCoverBackground !in map &&
-                    BackupConfig.keyIsNotIgnore(PreferKey.bookInfoBackgroundBlur) &&
-                    BackupConfig.keyIsNotIgnore(PreferKey.bookInfoDefaultCoverBackground)
-        appCtx.defaultSharedPreferences.edit {
-            map.forEach { (key, value) ->
-                if (BackupConfig.keyIsNotIgnore(key)) {
-                    when (key) {
-                        PreferKey.webDavPassword -> {
-                            val password = kotlin.runCatching {
-                                aes.decryptStr(value.toString())
-                            }.getOrNull() ?: let {
-                                if (appCtx.getPrefString(PreferKey.webDavPassword).isNullOrBlank()) {
-                                    value.toString()
-                                } else null
-                            }
-                            password?.let {
-                                putString(key, it)
-                                finalMap[key] = it
-                            }
-                        }
-
-                        else -> {
-                            if (value != null) {
-                                when (value) {
-                                    is Int -> { putInt(key, value); finalMap[key] = value }
-                                    is Boolean -> { putBoolean(key, value); finalMap[key] = value }
-                                    is Long -> { putLong(key, value); finalMap[key] = value }
-                                    is Double -> { // JSON 数字会被解析为 Double
-                                        val floatValue = value.toFloat()
-                                        putFloat(key, floatValue)
-                                        finalMap[key] = floatValue
-                                    }
-                                    is Float -> { putFloat(key, value); finalMap[key] = value }
-                                    is String -> { putString(key, value); finalMap[key] = value }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-            legacyBookInfoBackground?.let { backgroundMode ->
-                if (restoreNetworkCoverBackground) {
-                    putString(PreferKey.bookInfoNetworkCoverBackground, backgroundMode)
-                    finalMap[PreferKey.bookInfoNetworkCoverBackground] = backgroundMode
-                }
-                if (restoreDefaultCoverBackground) {
-                    putString(PreferKey.bookInfoDefaultCoverBackground, backgroundMode)
-                    finalMap[PreferKey.bookInfoDefaultCoverBackground] = backgroundMode
-                }
-            }
-        }
-        // 经快照层批量恢复：立即对读侧生效（onRestoreFinish 的读取不再依赖回灌时机），异步单次 edit 落盘
+        val finalMap = normalizeConfigMap(
+            map = map,
+            keyIsNotIgnore = { BackupConfig.keyIsNotIgnore(it) },
+            decryptWebDavPassword = { runCatching { aes.decryptStr(it) }.getOrNull() },
+            hasLocalWebDavPassword = !appCtx.getPrefString(PreferKey.webDavPassword)
+                .isNullOrBlank(),
+        )
+        // 经快照层批量恢复：立即对读侧生效（onRestoreFinish 的读取不再依赖回灌时机），单次原子 edit 落盘
         AppConfigStore.putAll(finalMap)
+        // 恢复完成提示前等待落盘，dataStore.edit 返回即持久化完成
+        DsSync.awaitPendingWrites()
     }
 
     private fun readXmlToMap(file: File): Map<String, Any?> {

--- a/app/src/main/java/io/legado/app/help/storage/RestoreConfigNormalizer.kt
+++ b/app/src/main/java/io/legado/app/help/storage/RestoreConfigNormalizer.kt
@@ -1,0 +1,46 @@
+package io.legado.app.help.storage
+
+import io.legado.app.constant.PreferKey
+
+/**
+ * 把 config.xml 解析出的原始键值规整为可直接批量写入设置存储的 map（纯函数，便于 JVM 单测）：
+ * - [PreferKey.webDavPassword]：AES 解密；解密失败时本地无密码则保留原文，否则丢弃；
+ * - Double 转 Float（JSON 数字会被解析为 Double）；
+ * - 旧版 [PreferKey.bookInfoBackgroundBlur] 拆分补写两个新背景键（备份中缺新键且未被忽略时）；
+ * - 过滤忽略键与 null 值。
+ */
+internal fun normalizeConfigMap(
+    map: Map<String, Any?>,
+    keyIsNotIgnore: (String) -> Boolean,
+    decryptWebDavPassword: (String) -> String?,
+    hasLocalWebDavPassword: Boolean,
+): Map<String, Any> {
+    val finalMap = mutableMapOf<String, Any>()
+    map.forEach { (key, value) ->
+        if (!keyIsNotIgnore(key)) return@forEach
+        when (key) {
+            PreferKey.webDavPassword -> {
+                val password = decryptWebDavPassword(value.toString())
+                    ?: value.toString().takeIf { !hasLocalWebDavPassword }
+                password?.let { finalMap[key] = it }
+            }
+
+            else -> when (value) {
+                is Double -> finalMap[key] = value.toFloat()
+                is Int, is Boolean, is Long, is Float, is String -> finalMap[key] = value
+            }
+        }
+    }
+    val legacyBookInfoBackground = map[PreferKey.bookInfoBackgroundBlur] as? String
+    if (legacyBookInfoBackground != null && keyIsNotIgnore(PreferKey.bookInfoBackgroundBlur)) {
+        listOf(
+            PreferKey.bookInfoNetworkCoverBackground,
+            PreferKey.bookInfoDefaultCoverBackground,
+        ).forEach { newKey ->
+            if (newKey !in map && keyIsNotIgnore(newKey)) {
+                finalMap[newKey] = legacyBookInfoBackground
+            }
+        }
+    }
+    return finalMap
+}

--- a/app/src/main/java/io/legado/app/service/BaseReadAloudService.kt
+++ b/app/src/main/java/io/legado/app/service/BaseReadAloudService.kt
@@ -37,6 +37,7 @@ import io.legado.app.constant.Status
 import io.legado.app.domain.model.PlaybackTimer
 import io.legado.app.help.MediaHelp
 import io.legado.app.help.config.AppConfig
+import io.legado.app.help.config.AppConfigStore
 import io.legado.app.ui.config.readConfig.ReadConfig
 import io.legado.app.help.coroutine.Coroutine
 import io.legado.app.help.glide.ImageLoader
@@ -51,13 +52,14 @@ import io.legado.app.utils.LogUtils
 import io.legado.app.utils.activityPendingIntent
 import io.legado.app.utils.getPrefBoolean
 import io.legado.app.utils.observeEvent
-import io.legado.app.utils.observeSharedPreferences
 import io.legado.app.utils.postEvent
 import io.legado.app.utils.toastOnUi
 import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.coroutines.Dispatchers.Main
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import splitties.init.appCtx
@@ -190,12 +192,12 @@ abstract class BaseReadAloudService : BaseService(),
             val startPos = it.getInt("startPos")
             newReadAloud(play, pageIndex, startPos)
         }
-        observeSharedPreferences { _, key ->
-            when (key) {
-                PreferKey.ignoreAudioFocus,
-                PreferKey.pauseReadAloudWhilePhoneCalls -> {
-                    initPhoneStateListener()
-                }
+        lifecycleScope.launch {
+            merge(
+                AppConfigStore.observeBoolean(PreferKey.ignoreAudioFocus).drop(1),
+                AppConfigStore.observeBoolean(PreferKey.pauseReadAloudWhilePhoneCalls).drop(1),
+            ).collect {
+                initPhoneStateListener()
             }
         }
     }

--- a/app/src/main/java/io/legado/app/ui/association/ImportReplaceRuleDialog.kt
+++ b/app/src/main/java/io/legado/app/ui/association/ImportReplaceRuleDialog.kt
@@ -124,7 +124,7 @@ class ImportReplaceRuleDialog() : BaseDialogFragment(R.layout.dialog_recycler_vi
             R.id.menu_new_group -> alertCustomGroup(item)
             R.id.menu_keep_original_name -> {
                 item.isChecked = !item.isChecked
-                putPrefBoolean(PreferKey.importKeepName, item.isChecked)
+                requireContext().putPrefBoolean(PreferKey.importKeepName, item.isChecked)
             }
         }
         return true

--- a/app/src/main/java/io/legado/app/ui/config/CheckSourceConfig.kt
+++ b/app/src/main/java/io/legado/app/ui/config/CheckSourceConfig.kt
@@ -93,7 +93,7 @@ class CheckSourceConfig : BaseBottomSheetDialogFragment(R.layout.dialog_check_so
                 checkCategory = binding.checkCategory.isChecked
                 checkContent = binding.checkContent.isChecked
                 putConfig()
-                putPrefString(PreferKey.checkSource, summary)
+                requireContext().putPrefString(PreferKey.checkSource, summary)
                 dismiss()
             }
         }

--- a/app/src/main/java/io/legado/app/ui/config/PrefDelegate.kt
+++ b/app/src/main/java/io/legado/app/ui/config/PrefDelegate.kt
@@ -23,7 +23,6 @@ import io.legado.app.utils.putPrefFloat
 import io.legado.app.utils.putPrefInt
 import io.legado.app.utils.putPrefLong
 import io.legado.app.utils.putPrefString
-import io.legado.app.utils.putPrefStringSync
 import io.legado.app.utils.removePref
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -48,7 +47,6 @@ fun <T> prefDelegate(
     key: String,
     defaultValue: T,
     lifecycleOwner: LifecycleOwner? = null,
-    sync: Boolean = false,
     onValueChange: ((T) -> Unit)? = null
 ): PrefDelegate<T> {
     return object : PrefDelegate<T>, DefaultLifecycleObserver {
@@ -148,9 +146,8 @@ fun <T> prefStateDelegate(
     key: String,
     defaultValue: T,
     lifecycleOwner: LifecycleOwner? = null,
-    sync: Boolean = false,
     onValueChange: ((T) -> Unit)? = null
 ): PrefStateDelegate<T> {
-    val delegate = prefDelegate(key, defaultValue, lifecycleOwner, sync, onValueChange)
+    val delegate = prefDelegate(key, defaultValue, lifecycleOwner, onValueChange)
     return PrefStateDelegate(delegate)
 }

--- a/app/src/main/java/io/legado/app/ui/config/PrefDelegate.kt
+++ b/app/src/main/java/io/legado/app/ui/config/PrefDelegate.kt
@@ -24,6 +24,7 @@ import io.legado.app.utils.putPrefInt
 import io.legado.app.utils.putPrefLong
 import io.legado.app.utils.putPrefString
 import io.legado.app.utils.putPrefStringSync
+import io.legado.app.utils.removePref
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -98,12 +99,16 @@ fun <T> prefDelegate(
         override fun setValue(thisRef: Any?, property: KProperty<*>, value: T) {
             if (currentValue != value) {
                 updateValue(value)
-                when (value) {
-                    is String? -> appCtx.putPrefString(key, value)
-                    is Int -> appCtx.putPrefInt(key, value)
-                    is Boolean -> appCtx.putPrefBoolean(key, value)
-                    is Long -> appCtx.putPrefLong(key, value)
-                    is Float -> appCtx.putPrefFloat(key, value)
+                if (value == null) {
+                    appCtx.removePref(key)
+                } else {
+                    when (value) {
+                        is String -> appCtx.putPrefString(key, value)
+                        is Int -> appCtx.putPrefInt(key, value)
+                        is Boolean -> appCtx.putPrefBoolean(key, value)
+                        is Long -> appCtx.putPrefLong(key, value)
+                        is Float -> appCtx.putPrefFloat(key, value)
+                    }
                 }
                 onValueChange?.invoke(value)
             }

--- a/app/src/main/java/io/legado/app/ui/config/PrefDelegate.kt
+++ b/app/src/main/java/io/legado/app/ui/config/PrefDelegate.kt
@@ -98,9 +98,8 @@ fun <T> prefDelegate(
         override fun setValue(thisRef: Any?, property: KProperty<*>, value: T) {
             if (currentValue != value) {
                 updateValue(value)
-                // 门面双写：SP（向后兼容，未迁移代码仍直接读 SP/靠 SP 监听）+ 快照/DataStore
                 when (value) {
-                    is String? -> if (sync) appCtx.putPrefStringSync(key, value) else appCtx.putPrefString(key, value)
+                    is String? -> appCtx.putPrefString(key, value)
                     is Int -> appCtx.putPrefInt(key, value)
                     is Boolean -> appCtx.putPrefBoolean(key, value)
                     is Long -> appCtx.putPrefLong(key, value)

--- a/app/src/main/java/io/legado/app/ui/config/PrefDelegate.kt
+++ b/app/src/main/java/io/legado/app/ui/config/PrefDelegate.kt
@@ -59,7 +59,7 @@ fun <T> prefDelegate(
         private var dsObserverJob: Job? = null
 
         init {
-            // 初值走门面：AppConfigStore 内存快照，DS 缺值时门面内回退 SP 并补写
+            // 初值走门面：AppConfigStore 内存快照（DataStore 唯一真源）
             val initialValue = readInitial()
             _value = mutableStateOf(initialValue)
             currentValue = initialValue

--- a/app/src/main/java/io/legado/app/ui/config/PrefDelegate.kt
+++ b/app/src/main/java/io/legado/app/ui/config/PrefDelegate.kt
@@ -4,16 +4,15 @@ import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.snapshots.Snapshot
-import androidx.datastore.preferences.core.booleanPreferencesKey
-import androidx.datastore.preferences.core.emptyPreferences
-import androidx.datastore.preferences.core.floatPreferencesKey
-import androidx.datastore.preferences.core.intPreferencesKey
-import androidx.datastore.preferences.core.longPreferencesKey
-import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.core.Preferences
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
-import io.legado.app.data.repository.dataStore
-import io.legado.app.help.config.DsSync
+import io.legado.app.help.config.AppConfigStore
+import io.legado.app.help.config.compatDsBoolean
+import io.legado.app.help.config.compatDsFloat
+import io.legado.app.help.config.compatDsInt
+import io.legado.app.help.config.compatDsLong
+import io.legado.app.help.config.compatDsString
 import io.legado.app.utils.getPrefBoolean
 import io.legado.app.utils.getPrefFloat
 import io.legado.app.utils.getPrefInt
@@ -26,15 +25,12 @@ import io.legado.app.utils.putPrefLong
 import io.legado.app.utils.putPrefString
 import io.legado.app.utils.putPrefStringSync
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import splitties.init.appCtx
-import java.io.IOException
 import kotlin.properties.ReadWriteProperty
 import kotlin.reflect.KProperty
 
@@ -60,44 +56,19 @@ fun <T> prefDelegate(
 
         @Volatile
         private var currentValue: T = defaultValue
-        private val scope = CoroutineScope(kotlinx.coroutines.Dispatchers.IO)
-
-        // 单并发调度器保证同一 key 的 DataStore 写入按提交顺序落盘
-        @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
-        private val dsWriteDispatcher = kotlinx.coroutines.Dispatchers.IO.limitedParallelism(1)
+        private val scope = CoroutineScope(Dispatchers.IO)
         private var dsObserverJob: Job? = null
 
         init {
-            // 同步从 DataStore 读取初始值，确保构造完成后即为最新值
-            val initialValue = runBlocking { readFromDs() } ?: defaultValue
+            // 初值走门面：AppConfigStore 内存快照，DS 缺值时门面内回退 SP 并补写
+            val initialValue = readInitial()
             _value = mutableStateOf(initialValue)
             currentValue = initialValue
 
-            // 观察 DataStore 变化，用于跨实例同步
+            // 观察快照变化，用于跨实例同步（含未落盘的 pending 写入，写后立即可见）
             dsObserverJob = scope.launch {
-                appCtx.dataStore.data
-                    .catch { if (it is IOException) emit(emptyPreferences()) else throw it }
-                    .map { prefs ->
-                        val strVal = runCatching { prefs[stringPreferencesKey(key)] }.getOrNull()
-                        @Suppress("UNCHECKED_CAST")
-                        when {
-                            defaultValue is String || defaultValue == null ->
-                                strVal as T?
-                            defaultValue is Int ->
-                                (runCatching { prefs[intPreferencesKey(key)] }.getOrNull()
-                                    ?: strVal?.toIntOrNull()) as T?
-                            defaultValue is Boolean ->
-                                (runCatching { prefs[booleanPreferencesKey(key)] }.getOrNull()
-                                    ?: strVal?.toBooleanStrictOrNull()) as T?
-                            defaultValue is Long ->
-                                (runCatching { prefs[longPreferencesKey(key)] }.getOrNull()
-                                    ?: strVal?.toLongOrNull()) as T?
-                            defaultValue is Float ->
-                                (runCatching { prefs[floatPreferencesKey(key)] }.getOrNull()
-                                    ?: strVal?.toFloatOrNull()) as T?
-                            else -> null
-                        }
-                    }
+                AppConfigStore.preferencesFlow
+                    .map { prefs -> readTyped(prefs) }
                     .distinctUntilChanged()
                     .collect { dsValue ->
                         if (dsValue != null && currentValue != dsValue) {
@@ -127,7 +98,7 @@ fun <T> prefDelegate(
         override fun setValue(thisRef: Any?, property: KProperty<*>, value: T) {
             if (currentValue != value) {
                 updateValue(value)
-                // 同步写入 SP（向后兼容：AppConfig/MainViewModel 等仍直接读 SP）
+                // 门面双写：SP（向后兼容，未迁移代码仍直接读 SP/靠 SP 监听）+ 快照/DataStore
                 when (value) {
                     is String? -> if (sync) appCtx.putPrefStringSync(key, value) else appCtx.putPrefString(key, value)
                     is Int -> appCtx.putPrefInt(key, value)
@@ -135,84 +106,29 @@ fun <T> prefDelegate(
                     is Long -> appCtx.putPrefLong(key, value)
                     is Float -> appCtx.putPrefFloat(key, value)
                 }
-                // 异步串行写入 DataStore；runBlocking 会把整文件重写 + fsync
-                // 挂在调用线程（通常是主线程的点击回调）上，造成明显掉帧
-                scope.launch(dsWriteDispatcher) {
-                    runCatching {
-                        when (value) {
-                            is String? -> DsSync.putString(key, value)
-                            is Int -> DsSync.putInt(key, value)
-                            is Boolean -> DsSync.putBoolean(key, value)
-                            is Long -> DsSync.putLong(key, value)
-                            is Float -> DsSync.putFloat(key, value)
-                        }
-                    }
-                }
                 onValueChange?.invoke(value)
             }
         }
 
-        /**
-         * 从 DataStore 读取当前值，DS 读不到时回退到 SP 并补写入 DS。
-         */
         @Suppress("UNCHECKED_CAST")
-        private suspend fun readFromDs(): T? {
-            val dsValue = try {
-                appCtx.dataStore.data
-                    .catch { if (it is IOException) emit(emptyPreferences()) else throw it }
-                    .map { prefs ->
-                        val strVal = runCatching { prefs[stringPreferencesKey(key)] }.getOrNull()
-                        when {
-                            defaultValue is String || defaultValue == null ->
-                                strVal as T?
-                            defaultValue is Int ->
-                                (runCatching { prefs[intPreferencesKey(key)] }.getOrNull()
-                                    ?: strVal?.toIntOrNull()) as T?
-                            defaultValue is Boolean ->
-                                (runCatching { prefs[booleanPreferencesKey(key)] }.getOrNull()
-                                    ?: strVal?.toBooleanStrictOrNull()) as T?
-                            defaultValue is Long ->
-                                (runCatching { prefs[longPreferencesKey(key)] }.getOrNull()
-                                    ?: strVal?.toLongOrNull()) as T?
-                            defaultValue is Float ->
-                                (runCatching { prefs[floatPreferencesKey(key)] }.getOrNull()
-                                    ?: strVal?.toFloatOrNull()) as T?
-                            else -> null
-                        }
-                    }
-                    .first()
-            } catch (e: Exception) {
-                null
-            }
-            // DS 有值，直接返回
-            if (dsValue != null) return dsValue
-            // DS 无值，回退到 SP（迁移遗漏时的补偿）
-            val spValue: T? = when {
-                defaultValue is String || defaultValue == null ->
-                    appCtx.getPrefString(key, defaultValue as String?) as T?
-                defaultValue is Int ->
-                    appCtx.getPrefInt(key, defaultValue) as T
-                defaultValue is Boolean ->
-                    appCtx.getPrefBoolean(key, defaultValue) as T
-                defaultValue is Long ->
-                    appCtx.getPrefLong(key, defaultValue) as T
-                defaultValue is Float ->
-                    appCtx.getPrefFloat(key, defaultValue) as T
-                else -> null
-            }
-            // DS 无值时，将 SP 值补写入 DS（修复迁移遗漏）
-            if (spValue != null) {
-                runCatching {
-                    when (spValue) {
-                        is String? -> DsSync.putString(key, spValue)
-                        is Int -> DsSync.putInt(key, spValue)
-                        is Boolean -> DsSync.putBoolean(key, spValue)
-                        is Long -> DsSync.putLong(key, spValue)
-                        is Float -> DsSync.putFloat(key, spValue)
-                    }
-                }
-            }
-            return spValue
+        private fun readInitial(): T = when {
+            defaultValue is String || defaultValue == null ->
+                appCtx.getPrefString(key, defaultValue as String?) as T
+            defaultValue is Int -> appCtx.getPrefInt(key, defaultValue) as T
+            defaultValue is Boolean -> appCtx.getPrefBoolean(key, defaultValue) as T
+            defaultValue is Long -> appCtx.getPrefLong(key, defaultValue) as T
+            defaultValue is Float -> appCtx.getPrefFloat(key, defaultValue) as T
+            else -> defaultValue
+        }
+
+        @Suppress("UNCHECKED_CAST")
+        private fun readTyped(prefs: Preferences): T? = when {
+            defaultValue is String || defaultValue == null -> prefs.compatDsString(key) as T?
+            defaultValue is Int -> prefs.compatDsInt(key) as T?
+            defaultValue is Boolean -> prefs.compatDsBoolean(key) as T?
+            defaultValue is Long -> prefs.compatDsLong(key) as T?
+            defaultValue is Float -> prefs.compatDsFloat(key) as T?
+            else -> null
         }
 
         private fun updateValue(value: T) {

--- a/app/src/main/java/io/legado/app/ui/config/otherConfig/OtherConfig.kt
+++ b/app/src/main/java/io/legado/app/ui/config/otherConfig/OtherConfig.kt
@@ -1,15 +1,24 @@
 package io.legado.app.ui.config.otherConfig
 
+import androidx.core.os.LocaleListCompat
 import io.legado.app.constant.PreferKey
 import io.legado.app.ui.config.downloadCacheConfig.DownloadCacheConfig
 import io.legado.app.ui.config.prefDelegate
+import java.util.Locale
+
+/** 语言偏好值 → per-app locale 列表；"auto" 及未知值返回空列表（跟随系统） */
+fun appLocaleListFor(language: String?): LocaleListCompat = when (language) {
+    "zh" -> LocaleListCompat.create(Locale.SIMPLIFIED_CHINESE)
+    "tw" -> LocaleListCompat.create(Locale.TRADITIONAL_CHINESE)
+    "en" -> LocaleListCompat.create(Locale.ENGLISH)
+    else -> LocaleListCompat.getEmptyLocaleList()
+}
 
 object OtherConfig {
 
     var language by prefDelegate(
         PreferKey.language,
-        "auto",
-        sync = true
+        "auto"
     )
 
     var updateToVariant by prefDelegate(

--- a/app/src/main/java/io/legado/app/ui/config/otherConfig/OtherConfigScreen.kt
+++ b/app/src/main/java/io/legado/app/ui/config/otherConfig/OtherConfigScreen.kt
@@ -5,6 +5,7 @@ import android.os.Build
 import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.appcompat.app.AppCompatDelegate
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.lazy.LazyColumn
@@ -22,6 +23,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import io.legado.app.R
+import androidx.core.os.LocaleListCompat
 import io.legado.app.service.WebService
 import io.legado.app.ui.config.readMangaConfig.ReadMangaConfig
 import io.legado.app.ui.theme.LegadoTheme
@@ -38,9 +40,9 @@ import io.legado.app.ui.widget.components.settingItem.SwitchSettingItem
 import io.legado.app.ui.widget.components.topbar.GlassMediumFlexibleTopAppBar
 import io.legado.app.ui.widget.components.topbar.GlassTopAppBarDefaults
 import io.legado.app.ui.widget.components.topbar.TopBarNavigationButton
-import io.legado.app.utils.restart
 import io.legado.app.utils.takePersistablePermissionSafely
 import org.koin.androidx.compose.koinViewModel
+import java.util.Locale
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -104,7 +106,13 @@ fun OtherConfigScreen(
                     entryValues = stringArrayResource(R.array.language_value),
                     onValueChange = { newValue ->
                         OtherConfig.language = newValue
-                        context.restart()
+                        val localeList = when (newValue) {
+                            "zh" -> LocaleListCompat.create(Locale.SIMPLIFIED_CHINESE)
+                            "tw" -> LocaleListCompat.create(Locale.TRADITIONAL_CHINESE)
+                            "en" -> LocaleListCompat.create(Locale.ENGLISH)
+                            else -> LocaleListCompat.getEmptyLocaleList()
+                        }
+                        AppCompatDelegate.setApplicationLocales(localeList)
                     }
                 )
 

--- a/app/src/main/java/io/legado/app/ui/config/otherConfig/OtherConfigScreen.kt
+++ b/app/src/main/java/io/legado/app/ui/config/otherConfig/OtherConfigScreen.kt
@@ -23,7 +23,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import io.legado.app.R
-import androidx.core.os.LocaleListCompat
 import io.legado.app.service.WebService
 import io.legado.app.ui.config.readMangaConfig.ReadMangaConfig
 import io.legado.app.ui.theme.LegadoTheme
@@ -42,7 +41,6 @@ import io.legado.app.ui.widget.components.topbar.GlassTopAppBarDefaults
 import io.legado.app.ui.widget.components.topbar.TopBarNavigationButton
 import io.legado.app.utils.takePersistablePermissionSafely
 import org.koin.androidx.compose.koinViewModel
-import java.util.Locale
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -106,13 +104,7 @@ fun OtherConfigScreen(
                     entryValues = stringArrayResource(R.array.language_value),
                     onValueChange = { newValue ->
                         OtherConfig.language = newValue
-                        val localeList = when (newValue) {
-                            "zh" -> LocaleListCompat.create(Locale.SIMPLIFIED_CHINESE)
-                            "tw" -> LocaleListCompat.create(Locale.TRADITIONAL_CHINESE)
-                            "en" -> LocaleListCompat.create(Locale.ENGLISH)
-                            else -> LocaleListCompat.getEmptyLocaleList()
-                        }
-                        AppCompatDelegate.setApplicationLocales(localeList)
+                        AppCompatDelegate.setApplicationLocales(appLocaleListFor(newValue))
                     }
                 )
 

--- a/app/src/main/java/io/legado/app/ui/config/themeConfig/ThemeConfig.kt
+++ b/app/src/main/java/io/legado/app/ui/config/themeConfig/ThemeConfig.kt
@@ -117,9 +117,10 @@ object ThemeConfig {
 
     var bgImageNBlurring by prefDelegate(PreferKey.bgImageNBlurring, 0)
 
-    var isPredictiveBackEnabled by prefDelegate(PreferKey.isPredictiveBackEnabled, true) {
-        postEvent(EventBus.RECREATE, "")
-    }
+    // 无需 RECREATE：Compose 消费点（BackHandler enabled / predictivePopTransitionSpec）
+    // 读的是 prefDelegate 的 Compose state，切换即时生效；View 系 Activity 在下次
+    // onCreate 时按新值注册 OnBackInvokedCallback（与旧版行为一致）
+    var isPredictiveBackEnabled by prefDelegate(PreferKey.isPredictiveBackEnabled, true)
 
     var customMode by prefDelegate<String?>(PreferKey.customMode, "tonalSpot")
 

--- a/app/src/main/java/io/legado/app/ui/config/themeConfig/ThemeConfig.kt
+++ b/app/src/main/java/io/legado/app/ui/config/themeConfig/ThemeConfig.kt
@@ -117,7 +117,9 @@ object ThemeConfig {
 
     var bgImageNBlurring by prefDelegate(PreferKey.bgImageNBlurring, 0)
 
-    var isPredictiveBackEnabled by prefDelegate(PreferKey.isPredictiveBackEnabled, true)
+    var isPredictiveBackEnabled by prefDelegate(PreferKey.isPredictiveBackEnabled, true) {
+        postEvent(EventBus.RECREATE, "")
+    }
 
     var customMode by prefDelegate<String?>(PreferKey.customMode, "tonalSpot")
 

--- a/app/src/main/java/io/legado/app/ui/config/themeConfig/ThemeConfigScreen.kt
+++ b/app/src/main/java/io/legado/app/ui/config/themeConfig/ThemeConfigScreen.kt
@@ -344,7 +344,6 @@ fun ThemeConfigScreen(
                         checked = ThemeConfig.isPredictiveBackEnabled,
                         onCheckedChange = {
                             ThemeConfig.isPredictiveBackEnabled = it
-                            context.toastOnUi(R.string.restart_to_apply)
                         }
                     )
                     SliderSettingItem(

--- a/app/src/main/java/io/legado/app/ui/config/themeManage/ThemeManageScreen.kt
+++ b/app/src/main/java/io/legado/app/ui/config/themeManage/ThemeManageScreen.kt
@@ -1,7 +1,5 @@
 package io.legado.app.ui.config.themeManage
 
-import android.os.Handler
-import android.os.Looper
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
@@ -41,7 +39,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import io.legado.app.R
-import io.legado.app.constant.EventBus
 import io.legado.app.help.config.SavedTheme
 import io.legado.app.help.config.ThemePackageManager
 import io.legado.app.ui.theme.adaptiveContentPadding
@@ -56,7 +53,6 @@ import io.legado.app.ui.widget.components.text.AppText
 import io.legado.app.ui.widget.components.topbar.GlassMediumFlexibleTopAppBar
 import io.legado.app.ui.widget.components.topbar.GlassTopAppBarDefaults
 import io.legado.app.ui.widget.components.topbar.TopBarNavigationButton
-import io.legado.app.utils.postEvent
 import io.legado.app.utils.toastOnUi
 import kotlinx.coroutines.flow.collectLatest
 import org.koin.androidx.compose.koinViewModel
@@ -115,12 +111,6 @@ fun ThemeManageScreen(
     LaunchedEffect(Unit) {
         viewModel.effects.collectLatest { effect ->
             when (effect) {
-                ThemeManageEffect.RestartRequired -> {
-                    Handler(Looper.getMainLooper()).postDelayed({
-                        postEvent(EventBus.RECREATE, "")
-                    }, 100)
-                }
-
                 is ThemeManageEffect.LegacyMigrationFinished -> {
                     val message = if (effect.failedCount == 0) {
                         context.getString(
@@ -146,11 +136,6 @@ fun ThemeManageScreen(
                         }
                     }
                     context.toastOnUi(message)
-                    if (effect.restartRequired) {
-                        Handler(Looper.getMainLooper()).postDelayed({
-                            postEvent(EventBus.RECREATE, "")
-                        }, 100)
-                    }
                 }
             }
         }
@@ -256,8 +241,6 @@ fun ThemeManageScreen(
             }
         }
     }
-
-
 
     // Save theme dialog
     AppAlertDialog(

--- a/app/src/main/java/io/legado/app/ui/config/themeManage/ThemeManageScreen.kt
+++ b/app/src/main/java/io/legado/app/ui/config/themeManage/ThemeManageScreen.kt
@@ -77,7 +77,6 @@ fun ThemeManageScreen(
     var applyTarget by remember { mutableStateOf<SavedTheme?>(null) }
     var exportTarget by remember { mutableStateOf<SavedTheme?>(null) }
     var editTarget by remember { mutableStateOf<SavedTheme?>(null) }
-    var showRestartDialog by remember { mutableStateOf(false) }
     val savedThemes = state.savedThemes
 
     val exportLauncher = rememberLauncherForActivityResult(
@@ -117,7 +116,9 @@ fun ThemeManageScreen(
         viewModel.effects.collectLatest { effect ->
             when (effect) {
                 ThemeManageEffect.RestartRequired -> {
-                    showRestartDialog = true
+                    Handler(Looper.getMainLooper()).postDelayed({
+                        postEvent(EventBus.RECREATE, "")
+                    }, 100)
                 }
 
                 is ThemeManageEffect.LegacyMigrationFinished -> {
@@ -146,7 +147,9 @@ fun ThemeManageScreen(
                     }
                     context.toastOnUi(message)
                     if (effect.restartRequired) {
-                        showRestartDialog = true
+                        Handler(Looper.getMainLooper()).postDelayed({
+                            postEvent(EventBus.RECREATE, "")
+                        }, 100)
                     }
                 }
             }
@@ -254,25 +257,7 @@ fun ThemeManageScreen(
         }
     }
 
-    // Restart dialog
-    // TODO: 后续降级为纯重组，参考 ThemeConfigStore.applyDayNightLive
-    AppAlertDialog(
-        show = showRestartDialog,
-        onDismissRequest = { showRestartDialog = false },
-        title = stringResource(R.string.restart_required_message),
-        onConfirm = {
-            showRestartDialog = false
-            Handler(Looper.getMainLooper()).postDelayed({
-                postEvent(EventBus.RECREATE, "")
-            }, 100)
-        },
-        confirmText = stringResource(R.string.ok),
-        onDismiss = {
-            showRestartDialog = false
-            context.toastOnUi(R.string.restart_later_message)
-        },
-        dismissText = stringResource(R.string.cancel)
-    )
+
 
     // Save theme dialog
     AppAlertDialog(

--- a/app/src/main/java/io/legado/app/ui/config/themeManage/ThemeManageScreen.kt
+++ b/app/src/main/java/io/legado/app/ui/config/themeManage/ThemeManageScreen.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import io.legado.app.R
+import io.legado.app.constant.EventBus
 import io.legado.app.help.config.SavedTheme
 import io.legado.app.help.config.ThemePackageManager
 import io.legado.app.ui.theme.adaptiveContentPadding
@@ -55,7 +56,7 @@ import io.legado.app.ui.widget.components.text.AppText
 import io.legado.app.ui.widget.components.topbar.GlassMediumFlexibleTopAppBar
 import io.legado.app.ui.widget.components.topbar.GlassTopAppBarDefaults
 import io.legado.app.ui.widget.components.topbar.TopBarNavigationButton
-import io.legado.app.utils.restart
+import io.legado.app.utils.postEvent
 import io.legado.app.utils.toastOnUi
 import kotlinx.coroutines.flow.collectLatest
 import org.koin.androidx.compose.koinViewModel
@@ -254,6 +255,7 @@ fun ThemeManageScreen(
     }
 
     // Restart dialog
+    // TODO: 后续降级为纯重组，参考 ThemeConfigStore.applyDayNightLive
     AppAlertDialog(
         show = showRestartDialog,
         onDismissRequest = { showRestartDialog = false },
@@ -261,7 +263,7 @@ fun ThemeManageScreen(
         onConfirm = {
             showRestartDialog = false
             Handler(Looper.getMainLooper()).postDelayed({
-                context.restart()
+                postEvent(EventBus.RECREATE, "")
             }, 100)
         },
         confirmText = stringResource(R.string.ok),

--- a/app/src/main/java/io/legado/app/ui/config/themeManage/ThemeManageViewModel.kt
+++ b/app/src/main/java/io/legado/app/ui/config/themeManage/ThemeManageViewModel.kt
@@ -106,8 +106,9 @@ class ThemeManageViewModel(
             _uiState.update { it.copy(loading = true) }
             val result = themePackageManager.applySavedTheme(theme)
             if (result.isSuccess) {
+                // 主题键均为 Compose 响应式读取，写入即生效；fontScale/自定义色等
+                // 需要重建的键由各自 prefDelegate 的 RECREATE 回调按需触发
                 refreshSavedThemes()
-                _effects.emit(ThemeManageEffect.RestartRequired)
             } else {
                 _uiState.update { it.copy(loading = false) }
                 _effects.emit(
@@ -179,7 +180,6 @@ class ThemeManageViewModel(
             if (result.isSuccess) {
                 ThemeManageEffect.ShowResult(
                     messageRes = R.string.theme_manage_import_success,
-                    restartRequired = true,
                 )
             } else {
                 ThemeManageEffect.ShowResult(
@@ -248,8 +248,6 @@ sealed interface ThemeManageIntent {
 }
 
 sealed interface ThemeManageEffect {
-    data object RestartRequired : ThemeManageEffect
-
     data class LegacyMigrationFinished(
         val migratedCount: Int,
         val failedCount: Int,
@@ -258,6 +256,5 @@ sealed interface ThemeManageEffect {
     data class ShowResult(
         @param:StringRes val messageRes: Int,
         val detail: String? = null,
-        val restartRequired: Boolean = false,
     ) : ThemeManageEffect
 }

--- a/app/src/main/java/io/legado/app/utils/ContextExtensions.kt
+++ b/app/src/main/java/io/legado/app/utils/ContextExtensions.kt
@@ -43,6 +43,7 @@ import io.legado.app.constant.AppConst
 import io.legado.app.data.entities.Book
 import io.legado.app.help.IntentHelp
 import io.legado.app.help.config.AppConfigStore
+import io.legado.app.help.config.DsSync
 import io.legado.app.help.book.isAudio
 import io.legado.app.help.book.isImage
 import io.legado.app.help.book.isLocal
@@ -52,6 +53,7 @@ import io.legado.app.ui.book.audio.AudioPlayActivity
 import io.legado.app.ui.book.manga.ReadMangaActivity
 import io.legado.app.ui.main.MainActivity
 import io.legado.app.ui.main.bookshelf.BookShelfItem
+import kotlinx.coroutines.runBlocking
 import splitties.systemservices.clipboardManager
 import splitties.systemservices.connectivityManager
 import splitties.systemservices.uiModeManager
@@ -288,10 +290,6 @@ fun Context.putPrefString(key: String, value: String?) {
     AppConfigStore.putString(key, value)
 }
 
-fun Context.putPrefStringSync(key: String, value: String?) {
-    putPrefString(key, value)
-}
-
 fun Context.getPrefStringSet(
     key: String,
     defValue: MutableSet<String>? = null,
@@ -339,8 +337,8 @@ fun Context.restart() {
                     or Intent.FLAG_ACTIVITY_CLEAR_TASK
                     or Intent.FLAG_ACTIVITY_CLEAR_TOP
         )
-        kotlinx.coroutines.runBlocking {
-            io.legado.app.help.config.DsSync.awaitPendingWrites()
+        runBlocking {
+            DsSync.awaitPendingWrites()
         }
         startActivity(intent)
         //杀掉以前进程

--- a/app/src/main/java/io/legado/app/utils/ContextExtensions.kt
+++ b/app/src/main/java/io/legado/app/utils/ContextExtensions.kt
@@ -42,6 +42,7 @@ import io.legado.app.R
 import io.legado.app.constant.AppConst
 import io.legado.app.data.entities.Book
 import io.legado.app.help.IntentHelp
+import io.legado.app.help.config.AppConfigStore
 import io.legado.app.help.book.isAudio
 import io.legado.app.help.book.isImage
 import io.legado.app.help.book.isLocal
@@ -185,63 +186,121 @@ fun Context.startForegroundServiceCompat(intent: Intent) {
 val Context.defaultSharedPreferences: SharedPreferences
     get() = PreferenceManager.getDefaultSharedPreferences(this)
 
-fun Context.getPrefBoolean(key: String, defValue: Boolean = false) =
-    defaultSharedPreferences.getBoolean(key, defValue)
+// getPref*/putPref* 门面：读取走 AppConfigStore 内存快照（DataStore），
+// DS 缺值时回退 SP 并补写 DS（迁移遗漏补偿，过渡期逻辑，后续删除）；
+// 写入仍保持 SP 双写（SP 监听器与直读 SP 的代码尚未迁移完），同时进快照保证写后立即读一致。
+// AppConfigStore 未初始化时（App.onCreate 之前，如 ContentProvider）直接走 SP 旧路径。
 
-fun Context.putPrefBoolean(key: String, value: Boolean = false) =
+fun Context.getPrefBoolean(key: String, defValue: Boolean = false): Boolean {
+    if (!AppConfigStore.isInitialized) return defaultSharedPreferences.getBoolean(key, defValue)
+    AppConfigStore.getBoolean(key)?.let { return it }
+    if (!defaultSharedPreferences.contains(key)) return defValue
+    val value = defaultSharedPreferences.getBoolean(key, defValue)
+    AppConfigStore.putBoolean(key, value)
+    return value
+}
+
+fun Context.putPrefBoolean(key: String, value: Boolean = false) {
     defaultSharedPreferences.edit { putBoolean(key, value) }
+    if (AppConfigStore.isInitialized) AppConfigStore.putBoolean(key, value)
+}
 
-fun Context.getPrefInt(key: String, defValue: Int = 0) =
-    defaultSharedPreferences.getInt(key, defValue)
+fun Context.getPrefInt(key: String, defValue: Int = 0): Int {
+    if (!AppConfigStore.isInitialized) return defaultSharedPreferences.getInt(key, defValue)
+    AppConfigStore.getInt(key)?.let { return it }
+    if (!defaultSharedPreferences.contains(key)) return defValue
+    val value = defaultSharedPreferences.getInt(key, defValue)
+    AppConfigStore.putInt(key, value)
+    return value
+}
 
-fun Context.putPrefInt(key: String, value: Int) =
+fun Context.putPrefInt(key: String, value: Int) {
     defaultSharedPreferences.edit { putInt(key, value) }
+    if (AppConfigStore.isInitialized) AppConfigStore.putInt(key, value)
+}
 
 fun Context.getPrefLong(key: String, defValue: Long = 0L): Long {
-    return try {
+    if (AppConfigStore.isInitialized) {
+        AppConfigStore.getLong(key)?.let { return it }
+        if (!defaultSharedPreferences.contains(key)) return defValue
+    }
+    val value = try {
         defaultSharedPreferences.getLong(key, defValue)
     } catch (e: ClassCastException) {
-        val value = defaultSharedPreferences.getInt(key, defValue.toInt()).toLong()
-        defaultSharedPreferences.edit { putLong(key, value) }
-        value
+        val fixed = defaultSharedPreferences.getInt(key, defValue.toInt()).toLong()
+        defaultSharedPreferences.edit { putLong(key, fixed) }
+        fixed
     }
+    if (AppConfigStore.isInitialized) AppConfigStore.putLong(key, value)
+    return value
 }
 
-fun Context.putPrefLong(key: String, value: Long) =
+fun Context.putPrefLong(key: String, value: Long) {
     defaultSharedPreferences.edit { putLong(key, value) }
+    if (AppConfigStore.isInitialized) AppConfigStore.putLong(key, value)
+}
 
 fun Context.getPrefFloat(key: String, defValue: Float = 0f): Float {
-    return try {
+    if (AppConfigStore.isInitialized) {
+        AppConfigStore.getFloat(key)?.let { return it }
+        if (!defaultSharedPreferences.contains(key)) return defValue
+    }
+    val value = try {
         defaultSharedPreferences.getFloat(key, defValue)
     } catch (e: ClassCastException) {
-        val value = defaultSharedPreferences.getInt(key, defValue.toInt()).toFloat()
-        defaultSharedPreferences.edit { putFloat(key, value) }
-        value
+        val fixed = defaultSharedPreferences.getInt(key, defValue.toInt()).toFloat()
+        defaultSharedPreferences.edit { putFloat(key, fixed) }
+        fixed
     }
+    if (AppConfigStore.isInitialized) AppConfigStore.putFloat(key, value)
+    return value
 }
 
-fun Context.putPrefFloat(key: String, value: Float) =
+fun Context.putPrefFloat(key: String, value: Float) {
     defaultSharedPreferences.edit { putFloat(key, value) }
+    if (AppConfigStore.isInitialized) AppConfigStore.putFloat(key, value)
+}
 
-fun Context.getPrefString(key: String, defValue: String? = null) =
-    defaultSharedPreferences.getString(key, defValue)
+fun Context.getPrefString(key: String, defValue: String? = null): String? {
+    if (!AppConfigStore.isInitialized) return defaultSharedPreferences.getString(key, defValue)
+    AppConfigStore.getString(key)?.let { return it }
+    if (!defaultSharedPreferences.contains(key)) return defValue
+    val value = defaultSharedPreferences.getString(key, defValue)
+    if (value != null) AppConfigStore.putString(key, value)
+    return value
+}
 
-fun Context.putPrefString(key: String, value: String?) =
+fun Context.putPrefString(key: String, value: String?) {
     defaultSharedPreferences.edit { putString(key, value) }
+    if (AppConfigStore.isInitialized) AppConfigStore.putString(key, value)
+}
 
-fun Context.putPrefStringSync(key: String, value: String?) =
+fun Context.putPrefStringSync(key: String, value: String?) {
     defaultSharedPreferences.edit(commit = true) { putString(key, value) }
+    if (AppConfigStore.isInitialized) AppConfigStore.putString(key, value)
+}
 
 fun Context.getPrefStringSet(
     key: String,
     defValue: MutableSet<String>? = null,
-): MutableSet<String>? = defaultSharedPreferences.getStringSet(key, defValue)
+): MutableSet<String>? {
+    if (!AppConfigStore.isInitialized) return defaultSharedPreferences.getStringSet(key, defValue)
+    AppConfigStore.getStringSet(key)?.let { return it.toMutableSet() }
+    if (!defaultSharedPreferences.contains(key)) return defValue
+    val value = defaultSharedPreferences.getStringSet(key, defValue)
+    if (value != null) AppConfigStore.putStringSet(key, value.toSet())
+    return value
+}
 
-fun Context.putPrefStringSet(key: String, value: MutableSet<String>) =
+fun Context.putPrefStringSet(key: String, value: MutableSet<String>) {
     defaultSharedPreferences.edit { putStringSet(key, value) }
+    if (AppConfigStore.isInitialized) AppConfigStore.putStringSet(key, value.toSet())
+}
 
-fun Context.removePref(key: String) =
+fun Context.removePref(key: String) {
     defaultSharedPreferences.edit { remove(key) }
+    if (AppConfigStore.isInitialized) AppConfigStore.remove(key)
+}
 
 
 fun Context.getCompatColor(@ColorRes id: Int): Int = ContextCompat.getColor(this, id)

--- a/app/src/main/java/io/legado/app/utils/ContextExtensions.kt
+++ b/app/src/main/java/io/legado/app/utils/ContextExtensions.kt
@@ -16,7 +16,6 @@ import android.content.ClipData
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
-import android.content.SharedPreferences
 import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager
 import android.content.res.ColorStateList
@@ -34,16 +33,14 @@ import androidx.annotation.ColorRes
 import androidx.annotation.DrawableRes
 import androidx.core.content.ContextCompat
 import androidx.core.content.FileProvider
-import androidx.core.content.edit
 import androidx.core.net.toUri
-import androidx.preference.PreferenceManager
 import com.google.zxing.qrcode.decoder.ErrorCorrectionLevel
 import io.legado.app.R
 import io.legado.app.constant.AppConst
 import io.legado.app.data.entities.Book
 import io.legado.app.help.IntentHelp
 import io.legado.app.help.config.AppConfigStore
-import io.legado.app.help.config.DsSync
+import io.legado.app.help.config.SettingsWriter
 import io.legado.app.help.book.isAudio
 import io.legado.app.help.book.isImage
 import io.legado.app.help.book.isLocal
@@ -185,136 +182,55 @@ fun Context.startForegroundServiceCompat(intent: Intent) {
     }
 }
 
-val Context.defaultSharedPreferences: SharedPreferences
-    get() = PreferenceManager.getDefaultSharedPreferences(this)
-
 // getPref*/putPref* 门面：读写统一走 AppConfigStore 内存快照（DataStore 唯一真源），
-// 主线程零 IO。AppConfigStore 未初始化时（App.onCreate 之前，如 ContentProvider）走 SP 旧路径。
+// 主线程零 IO。须在 App.onCreate 首行 AppConfigStore.init() 之后使用。
 
-fun Context.getPrefBoolean(key: String, defValue: Boolean = false): Boolean {
-    if (!AppConfigStore.isInitialized) return defaultSharedPreferences.getBoolean(key, defValue)
-    AppConfigStore.getBoolean(key)?.let { return it }
-    if (!defaultSharedPreferences.contains(key)) return defValue
-    val value = defaultSharedPreferences.getBoolean(key, defValue)
-    AppConfigStore.putBoolean(key, value)
-    return value
-}
+fun Context.getPrefBoolean(key: String, defValue: Boolean = false): Boolean =
+    AppConfigStore.getBoolean(key) ?: defValue
 
 fun Context.putPrefBoolean(key: String, value: Boolean = false) {
-    if (!AppConfigStore.isInitialized) {
-        defaultSharedPreferences.edit { putBoolean(key, value) }
-        return
-    }
     AppConfigStore.putBoolean(key, value)
 }
 
-fun Context.getPrefInt(key: String, defValue: Int = 0): Int {
-    if (!AppConfigStore.isInitialized) return defaultSharedPreferences.getInt(key, defValue)
-    AppConfigStore.getInt(key)?.let { return it }
-    if (!defaultSharedPreferences.contains(key)) return defValue
-    val value = defaultSharedPreferences.getInt(key, defValue)
-    AppConfigStore.putInt(key, value)
-    return value
-}
+fun Context.getPrefInt(key: String, defValue: Int = 0): Int =
+    AppConfigStore.getInt(key) ?: defValue
 
 fun Context.putPrefInt(key: String, value: Int) {
-    if (!AppConfigStore.isInitialized) {
-        defaultSharedPreferences.edit { putInt(key, value) }
-        return
-    }
     AppConfigStore.putInt(key, value)
 }
 
-fun Context.getPrefLong(key: String, defValue: Long = 0L): Long {
-    if (AppConfigStore.isInitialized) {
-        AppConfigStore.getLong(key)?.let { return it }
-        if (!defaultSharedPreferences.contains(key)) return defValue
-    }
-    val value = try {
-        defaultSharedPreferences.getLong(key, defValue)
-    } catch (e: ClassCastException) {
-        val fixed = defaultSharedPreferences.getInt(key, defValue.toInt()).toLong()
-        defaultSharedPreferences.edit { putLong(key, fixed) }
-        fixed
-    }
-    if (AppConfigStore.isInitialized) AppConfigStore.putLong(key, value)
-    return value
-}
+fun Context.getPrefLong(key: String, defValue: Long = 0L): Long =
+    AppConfigStore.getLong(key) ?: defValue
 
 fun Context.putPrefLong(key: String, value: Long) {
-    if (!AppConfigStore.isInitialized) {
-        defaultSharedPreferences.edit { putLong(key, value) }
-        return
-    }
     AppConfigStore.putLong(key, value)
 }
 
-fun Context.getPrefFloat(key: String, defValue: Float = 0f): Float {
-    if (AppConfigStore.isInitialized) {
-        AppConfigStore.getFloat(key)?.let { return it }
-        if (!defaultSharedPreferences.contains(key)) return defValue
-    }
-    val value = try {
-        defaultSharedPreferences.getFloat(key, defValue)
-    } catch (e: ClassCastException) {
-        val fixed = defaultSharedPreferences.getInt(key, defValue.toInt()).toFloat()
-        defaultSharedPreferences.edit { putFloat(key, fixed) }
-        fixed
-    }
-    if (AppConfigStore.isInitialized) AppConfigStore.putFloat(key, value)
-    return value
-}
+fun Context.getPrefFloat(key: String, defValue: Float = 0f): Float =
+    AppConfigStore.getFloat(key) ?: defValue
 
 fun Context.putPrefFloat(key: String, value: Float) {
-    if (!AppConfigStore.isInitialized) {
-        defaultSharedPreferences.edit { putFloat(key, value) }
-        return
-    }
     AppConfigStore.putFloat(key, value)
 }
 
-fun Context.getPrefString(key: String, defValue: String? = null): String? {
-    if (!AppConfigStore.isInitialized) return defaultSharedPreferences.getString(key, defValue)
-    AppConfigStore.getString(key)?.let { return it }
-    if (!defaultSharedPreferences.contains(key)) return defValue
-    val value = defaultSharedPreferences.getString(key, defValue)
-    if (value != null) AppConfigStore.putString(key, value)
-    return value
-}
+fun Context.getPrefString(key: String, defValue: String? = null): String? =
+    AppConfigStore.getString(key) ?: defValue
 
 fun Context.putPrefString(key: String, value: String?) {
-    if (!AppConfigStore.isInitialized) {
-        defaultSharedPreferences.edit { putString(key, value) }
-        return
-    }
     AppConfigStore.putString(key, value)
 }
 
 fun Context.getPrefStringSet(
     key: String,
     defValue: MutableSet<String>? = null,
-): MutableSet<String>? {
-    if (!AppConfigStore.isInitialized) return defaultSharedPreferences.getStringSet(key, defValue)
-    AppConfigStore.getStringSet(key)?.let { return it.toMutableSet() }
-    if (!defaultSharedPreferences.contains(key)) return defValue
-    val value = defaultSharedPreferences.getStringSet(key, defValue)
-    if (value != null) AppConfigStore.putStringSet(key, value.toSet())
-    return value
-}
+): MutableSet<String>? =
+    AppConfigStore.getStringSet(key)?.toMutableSet() ?: defValue
 
 fun Context.putPrefStringSet(key: String, value: MutableSet<String>) {
-    if (!AppConfigStore.isInitialized) {
-        defaultSharedPreferences.edit { putStringSet(key, value) }
-        return
-    }
     AppConfigStore.putStringSet(key, value.toSet())
 }
 
 fun Context.removePref(key: String) {
-    if (!AppConfigStore.isInitialized) {
-        defaultSharedPreferences.edit { remove(key) }
-        return
-    }
     AppConfigStore.remove(key)
 }
 
@@ -338,7 +254,7 @@ fun Context.restart() {
                     or Intent.FLAG_ACTIVITY_CLEAR_TOP
         )
         runBlocking {
-            DsSync.awaitPendingWrites()
+            SettingsWriter.awaitPendingWrites()
         }
         startActivity(intent)
         //杀掉以前进程

--- a/app/src/main/java/io/legado/app/utils/ContextExtensions.kt
+++ b/app/src/main/java/io/legado/app/utils/ContextExtensions.kt
@@ -186,10 +186,8 @@ fun Context.startForegroundServiceCompat(intent: Intent) {
 val Context.defaultSharedPreferences: SharedPreferences
     get() = PreferenceManager.getDefaultSharedPreferences(this)
 
-// getPref*/putPref* 门面：读取走 AppConfigStore 内存快照（DataStore），
-// DS 缺值时回退 SP 并补写 DS（迁移遗漏补偿，过渡期逻辑，后续删除）；
-// 写入仍保持 SP 双写（SP 监听器与直读 SP 的代码尚未迁移完），同时进快照保证写后立即读一致。
-// AppConfigStore 未初始化时（App.onCreate 之前，如 ContentProvider）直接走 SP 旧路径。
+// getPref*/putPref* 门面：读写统一走 AppConfigStore 内存快照（DataStore 唯一真源），
+// 主线程零 IO。AppConfigStore 未初始化时（App.onCreate 之前，如 ContentProvider）走 SP 旧路径。
 
 fun Context.getPrefBoolean(key: String, defValue: Boolean = false): Boolean {
     if (!AppConfigStore.isInitialized) return defaultSharedPreferences.getBoolean(key, defValue)
@@ -201,8 +199,11 @@ fun Context.getPrefBoolean(key: String, defValue: Boolean = false): Boolean {
 }
 
 fun Context.putPrefBoolean(key: String, value: Boolean = false) {
-    defaultSharedPreferences.edit { putBoolean(key, value) }
-    if (AppConfigStore.isInitialized) AppConfigStore.putBoolean(key, value)
+    if (!AppConfigStore.isInitialized) {
+        defaultSharedPreferences.edit { putBoolean(key, value) }
+        return
+    }
+    AppConfigStore.putBoolean(key, value)
 }
 
 fun Context.getPrefInt(key: String, defValue: Int = 0): Int {
@@ -215,8 +216,11 @@ fun Context.getPrefInt(key: String, defValue: Int = 0): Int {
 }
 
 fun Context.putPrefInt(key: String, value: Int) {
-    defaultSharedPreferences.edit { putInt(key, value) }
-    if (AppConfigStore.isInitialized) AppConfigStore.putInt(key, value)
+    if (!AppConfigStore.isInitialized) {
+        defaultSharedPreferences.edit { putInt(key, value) }
+        return
+    }
+    AppConfigStore.putInt(key, value)
 }
 
 fun Context.getPrefLong(key: String, defValue: Long = 0L): Long {
@@ -236,8 +240,11 @@ fun Context.getPrefLong(key: String, defValue: Long = 0L): Long {
 }
 
 fun Context.putPrefLong(key: String, value: Long) {
-    defaultSharedPreferences.edit { putLong(key, value) }
-    if (AppConfigStore.isInitialized) AppConfigStore.putLong(key, value)
+    if (!AppConfigStore.isInitialized) {
+        defaultSharedPreferences.edit { putLong(key, value) }
+        return
+    }
+    AppConfigStore.putLong(key, value)
 }
 
 fun Context.getPrefFloat(key: String, defValue: Float = 0f): Float {
@@ -257,8 +264,11 @@ fun Context.getPrefFloat(key: String, defValue: Float = 0f): Float {
 }
 
 fun Context.putPrefFloat(key: String, value: Float) {
-    defaultSharedPreferences.edit { putFloat(key, value) }
-    if (AppConfigStore.isInitialized) AppConfigStore.putFloat(key, value)
+    if (!AppConfigStore.isInitialized) {
+        defaultSharedPreferences.edit { putFloat(key, value) }
+        return
+    }
+    AppConfigStore.putFloat(key, value)
 }
 
 fun Context.getPrefString(key: String, defValue: String? = null): String? {
@@ -271,13 +281,15 @@ fun Context.getPrefString(key: String, defValue: String? = null): String? {
 }
 
 fun Context.putPrefString(key: String, value: String?) {
-    defaultSharedPreferences.edit { putString(key, value) }
-    if (AppConfigStore.isInitialized) AppConfigStore.putString(key, value)
+    if (!AppConfigStore.isInitialized) {
+        defaultSharedPreferences.edit { putString(key, value) }
+        return
+    }
+    AppConfigStore.putString(key, value)
 }
 
 fun Context.putPrefStringSync(key: String, value: String?) {
-    defaultSharedPreferences.edit(commit = true) { putString(key, value) }
-    if (AppConfigStore.isInitialized) AppConfigStore.putString(key, value)
+    putPrefString(key, value)
 }
 
 fun Context.getPrefStringSet(
@@ -293,13 +305,19 @@ fun Context.getPrefStringSet(
 }
 
 fun Context.putPrefStringSet(key: String, value: MutableSet<String>) {
-    defaultSharedPreferences.edit { putStringSet(key, value) }
-    if (AppConfigStore.isInitialized) AppConfigStore.putStringSet(key, value.toSet())
+    if (!AppConfigStore.isInitialized) {
+        defaultSharedPreferences.edit { putStringSet(key, value) }
+        return
+    }
+    AppConfigStore.putStringSet(key, value.toSet())
 }
 
 fun Context.removePref(key: String) {
-    defaultSharedPreferences.edit { remove(key) }
-    if (AppConfigStore.isInitialized) AppConfigStore.remove(key)
+    if (!AppConfigStore.isInitialized) {
+        defaultSharedPreferences.edit { remove(key) }
+        return
+    }
+    AppConfigStore.remove(key)
 }
 
 
@@ -321,6 +339,9 @@ fun Context.restart() {
                     or Intent.FLAG_ACTIVITY_CLEAR_TASK
                     or Intent.FLAG_ACTIVITY_CLEAR_TOP
         )
+        kotlinx.coroutines.runBlocking {
+            io.legado.app.help.config.DsSync.awaitPendingWrites()
+        }
         startActivity(intent)
         //杀掉以前进程
         Process.killProcess(Process.myPid())

--- a/app/src/main/java/io/legado/app/utils/FragmentExtensions.kt
+++ b/app/src/main/java/io/legado/app/utils/FragmentExtensions.kt
@@ -9,7 +9,6 @@ import android.graphics.drawable.Drawable
 import android.os.Bundle
 import androidx.annotation.ColorRes
 import androidx.annotation.DrawableRes
-import androidx.core.content.edit
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Lifecycle
@@ -39,41 +38,43 @@ fun Fragment.showDialogFragment(dialogFragment: DialogFragment) {
     dialogFragment.show(childFragmentManager, dialogFragment::class.simpleName)
 }
 
+// 统一委托给 Context 门面（读快照、写双写），避免两套实现漂移
+
 fun Fragment.getPrefBoolean(key: String, defValue: Boolean = false) =
-    requireContext().defaultSharedPreferences.getBoolean(key, defValue)
+    requireContext().getPrefBoolean(key, defValue)
 
 fun Fragment.putPrefBoolean(key: String, value: Boolean = false) =
-    requireContext().defaultSharedPreferences.edit { putBoolean(key, value) }
+    requireContext().putPrefBoolean(key, value)
 
 fun Fragment.getPrefInt(key: String, defValue: Int = 0) =
-    requireContext().defaultSharedPreferences.getInt(key, defValue)
+    requireContext().getPrefInt(key, defValue)
 
 fun Fragment.putPrefInt(key: String, value: Int) =
-    requireContext().defaultSharedPreferences.edit { putInt(key, value) }
+    requireContext().putPrefInt(key, value)
 
 fun Fragment.getPrefLong(key: String, defValue: Long = 0L) =
-    requireContext().defaultSharedPreferences.getLong(key, defValue)
+    requireContext().getPrefLong(key, defValue)
 
 fun Fragment.putPrefLong(key: String, value: Long) =
-    requireContext().defaultSharedPreferences.edit { putLong(key, value) }
+    requireContext().putPrefLong(key, value)
 
 fun Fragment.getPrefString(key: String, defValue: String? = null) =
-    requireContext().defaultSharedPreferences.getString(key, defValue)
+    requireContext().getPrefString(key, defValue)
 
 fun Fragment.putPrefString(key: String, value: String) =
-    requireContext().defaultSharedPreferences.edit { putString(key, value) }
+    requireContext().putPrefString(key, value)
 
 fun Fragment.getPrefStringSet(
     key: String,
     defValue: MutableSet<String>? = null
 ): MutableSet<String>? =
-    requireContext().defaultSharedPreferences.getStringSet(key, defValue)
+    requireContext().getPrefStringSet(key, defValue)
 
 fun Fragment.putPrefStringSet(key: String, value: MutableSet<String>) =
-    requireContext().defaultSharedPreferences.edit { putStringSet(key, value) }
+    requireContext().putPrefStringSet(key, value)
 
 fun Fragment.removePref(key: String) =
-    requireContext().defaultSharedPreferences.edit { remove(key) }
+    requireContext().removePref(key)
 
 fun Fragment.getCompatColor(@ColorRes id: Int): Int = requireContext().getCompatColor(id)
 

--- a/app/src/main/java/io/legado/app/utils/FragmentExtensions.kt
+++ b/app/src/main/java/io/legado/app/utils/FragmentExtensions.kt
@@ -17,7 +17,6 @@ import io.legado.app.data.entities.Book
 import io.legado.app.help.book.isAudio
 import io.legado.app.help.book.isImage
 import io.legado.app.help.book.isLocal
-import io.legado.app.help.config.AppConfig
 import io.legado.app.ui.config.readMangaConfig.ReadMangaConfig
 import io.legado.app.ui.book.audio.AudioPlayActivity
 import io.legado.app.ui.book.manga.ReadMangaActivity
@@ -37,44 +36,6 @@ inline fun <reified T : DialogFragment> Fragment.showDialogFragment(
 fun Fragment.showDialogFragment(dialogFragment: DialogFragment) {
     dialogFragment.show(childFragmentManager, dialogFragment::class.simpleName)
 }
-
-// 统一委托给 Context 门面（读快照、写双写），避免两套实现漂移
-
-fun Fragment.getPrefBoolean(key: String, defValue: Boolean = false) =
-    requireContext().getPrefBoolean(key, defValue)
-
-fun Fragment.putPrefBoolean(key: String, value: Boolean = false) =
-    requireContext().putPrefBoolean(key, value)
-
-fun Fragment.getPrefInt(key: String, defValue: Int = 0) =
-    requireContext().getPrefInt(key, defValue)
-
-fun Fragment.putPrefInt(key: String, value: Int) =
-    requireContext().putPrefInt(key, value)
-
-fun Fragment.getPrefLong(key: String, defValue: Long = 0L) =
-    requireContext().getPrefLong(key, defValue)
-
-fun Fragment.putPrefLong(key: String, value: Long) =
-    requireContext().putPrefLong(key, value)
-
-fun Fragment.getPrefString(key: String, defValue: String? = null) =
-    requireContext().getPrefString(key, defValue)
-
-fun Fragment.putPrefString(key: String, value: String) =
-    requireContext().putPrefString(key, value)
-
-fun Fragment.getPrefStringSet(
-    key: String,
-    defValue: MutableSet<String>? = null
-): MutableSet<String>? =
-    requireContext().getPrefStringSet(key, defValue)
-
-fun Fragment.putPrefStringSet(key: String, value: MutableSet<String>) =
-    requireContext().putPrefStringSet(key, value)
-
-fun Fragment.removePref(key: String) =
-    requireContext().removePref(key)
 
 fun Fragment.getCompatColor(@ColorRes id: Int): Int = requireContext().getCompatColor(id)
 

--- a/app/src/main/java/io/legado/app/utils/PreferencesExtensions.kt
+++ b/app/src/main/java/io/legado/app/utils/PreferencesExtensions.kt
@@ -8,9 +8,6 @@ import android.content.Context
 import android.content.ContextWrapper
 import android.content.SharedPreferences
 import androidx.core.content.edit
-import androidx.lifecycle.DefaultLifecycleObserver
-import androidx.lifecycle.LifecycleOwner
-import splitties.init.appCtx
 import java.io.File
 
 /**
@@ -108,29 +105,4 @@ fun SharedPreferences.remove(key: String) {
     edit {
         remove(key)
     }
-}
-
-fun LifecycleOwner.observeSharedPreferences(
-    prefs: SharedPreferences = appCtx.defaultSharedPreferences,
-    l: SharedPreferences.OnSharedPreferenceChangeListener
-) {
-    val observer = object : DefaultLifecycleObserver {
-        override fun onCreate(owner: LifecycleOwner) {
-            prefs.registerOnSharedPreferenceChangeListener(l)
-        }
-
-        override fun onDestroy(owner: LifecycleOwner) {
-            prefs.unregisterOnSharedPreferenceChangeListener(l)
-            lifecycle.removeObserver(this)
-        }
-
-        override fun onPause(owner: LifecycleOwner) {
-            prefs.unregisterOnSharedPreferenceChangeListener(l)
-        }
-
-        override fun onResume(owner: LifecycleOwner) {
-            prefs.registerOnSharedPreferenceChangeListener(l)
-        }
-    }
-    lifecycle.addObserver(observer)
 }

--- a/app/src/test/java/io/legado/app/help/config/PendingOverlayCoreTest.kt
+++ b/app/src/test/java/io/legado/app/help/config/PendingOverlayCoreTest.kt
@@ -36,7 +36,7 @@ class PendingOverlayCoreTest {
             },
         )
 
-        /** 执行队列中下一个落盘任务（模拟 DsSync 串行队列跑完一个 Job） */
+        /** 执行队列中下一个落盘任务（模拟 SettingsWriter 串行队列跑完一个 Job） */
         fun completeNextWrite() = runBlocking { writeQueue.removeFirst().invoke() }
 
         fun read(key: String): Int? = core.preferencesFlow.value.compatDsInt(key)

--- a/app/src/test/java/io/legado/app/help/config/PendingOverlayCoreTest.kt
+++ b/app/src/test/java/io/legado/app/help/config/PendingOverlayCoreTest.kt
@@ -28,6 +28,12 @@ class PendingOverlayCoreTest {
                 dsState = mutable.toPreferences()
                 dsState
             },
+            persistAll = { values ->
+                val mutable = dsState.toMutablePreferences()
+                values.forEach { (key, value) -> mutable.setPrefValue(key, value) }
+                dsState = mutable.toPreferences()
+                dsState
+            },
         )
 
         /** 执行队列中下一个落盘任务（模拟 DsSync 串行队列跑完一个 Job） */
@@ -67,14 +73,47 @@ class PendingOverlayCoreTest {
         val h = Harness(mutablePreferencesOf(intPreferencesKey("k") to 1))
         h.core.put("k", 2)
         h.completeNextWrite()
-        // 落盘完成即采纳 edit 结果，读取已是新值
+        // 落盘完成后新值仍由 overlay 保护，读取已是新值
         assertEquals(2, h.read("k"))
-        // collector 随后携带落盘后的新状态回灌
+        // collector 携带落盘后的新状态回灌，确认后 overlay 移除
         h.core.onEmission(h.dsState)
         assertEquals(2, h.read("k"))
         // overlay 已清空：此后外部写入（如 Restore）的回灌可正常覆盖
         h.core.onEmission(mutablePreferencesOf(intPreferencesKey("k") to 5))
         assertEquals(5, h.read("k"))
+    }
+
+    @Test
+    fun `落盘完成后处理到旧回灌-读值不回滚`() {
+        val h = Harness(mutablePreferencesOf(intPreferencesKey("k") to 1))
+        h.core.put("k", 2)
+        h.completeNextWrite()
+        // collector 此时才处理一条落盘前排队的旧回灌，读值不得回滚（否则 observe
+        // 订阅方会收到 2→1→2 的幻影变更）
+        h.core.onEmission(mutablePreferencesOf(intPreferencesKey("k") to 1))
+        assertEquals(2, h.read("k"))
+        // 含新值的回灌到达后 overlay 才移除，外部写入随后可正常覆盖
+        h.core.onEmission(h.dsState)
+        assertEquals(2, h.read("k"))
+        h.core.onEmission(mutablePreferencesOf(intPreferencesKey("k") to 7))
+        assertEquals(7, h.read("k"))
+    }
+
+    @Test
+    fun `批量写入立即生效-单次落盘-回灌确认后清空 overlay`() {
+        val h = Harness(mutablePreferencesOf(intPreferencesKey("a") to 1))
+        h.core.putAll(mapOf("a" to 2, "b" to "x"))
+        // 写入内存立即可读，且只排一个落盘任务
+        assertEquals(2, h.read("a"))
+        assertEquals("x", h.core.preferencesFlow.value.compatDsString("b"))
+        assertEquals(1, h.writeQueue.size)
+        h.completeNextWrite()
+        assertEquals(2, h.dsState.compatDsInt("a"))
+        assertEquals("x", h.dsState.compatDsString("b"))
+        // 回灌确认后 overlay 清空，外部回灌可覆盖
+        h.core.onEmission(h.dsState)
+        h.core.onEmission(mutablePreferencesOf(intPreferencesKey("a") to 9))
+        assertEquals(9, h.read("a"))
     }
 
     @Test
@@ -130,6 +169,7 @@ class PendingOverlayCoreTest {
                 dsState = mutable.toPreferences()
                 dsState
             },
+            persistAll = { error("unused") },
         )
         core.put("k", 2)
         assertEquals(2, core.preferencesFlow.value.compatDsInt("k"))
@@ -163,6 +203,7 @@ class PendingOverlayCoreTest {
                 dsState = mutable.toPreferences()
                 dsState
             },
+            persistAll = { error("unused") },
         )
         // 第一次写入 2 (失败)
         core.put("k", 2)
@@ -185,7 +226,7 @@ class PendingOverlayCoreTest {
         // 执行第二个任务（成功）
         runBlocking { writeQueue.removeFirst().invoke() }
 
-        // 第二个成功，快照更新为 3，并且 overlay 彻底清空，读取为 3
+        // 第二个成功落盘，读取为 3（overlay 待回灌确认后清空）
         assertEquals(3, core.preferencesFlow.value.compatDsInt("k"))
         assertEquals(3, dsState.compatDsInt("k"))
     }

--- a/app/src/test/java/io/legado/app/help/config/PendingOverlayCoreTest.kt
+++ b/app/src/test/java/io/legado/app/help/config/PendingOverlayCoreTest.kt
@@ -112,4 +112,81 @@ class PendingOverlayCoreTest {
         assertEquals(2, h.dsState.compatDsInt("b"))
         assertEquals(h.dsState, h.core.preferencesFlow.value)
     }
+
+    @Test
+    fun `写入异常时-overlay仍被清空且回退到磁盘旧值`() {
+        var throwError = false
+        var dsState: Preferences = mutablePreferencesOf(intPreferencesKey("k") to 1)
+        val writeQueue = ArrayDeque<suspend () -> Unit>()
+        val core = PendingOverlayCore(
+            initial = dsState,
+            launchWrite = { writeQueue += it },
+            persist = { key, value ->
+                if (throwError) {
+                    throw java.io.IOException("Disk full")
+                }
+                val mutable = dsState.toMutablePreferences()
+                mutable.setPrefValue(key, value)
+                dsState = mutable.toPreferences()
+                dsState
+            },
+        )
+        core.put("k", 2)
+        assertEquals(2, core.preferencesFlow.value.compatDsInt("k"))
+
+        throwError = true
+        try {
+            runBlocking { writeQueue.removeFirst().invoke() }
+        } catch (e: Exception) {
+            // Expected
+        }
+
+        // 验证 overlay 已被清除，读取回退到快照中的旧值 1
+        assertEquals(1, core.preferencesFlow.value.compatDsInt("k"))
+    }
+
+    @Test
+    fun `同key连续写入-第一次失败第二次成功-最终正确应用第二次的值`() {
+        var firstWrite = true
+        var dsState: Preferences = mutablePreferencesOf(intPreferencesKey("k") to 1)
+        val writeQueue = ArrayDeque<suspend () -> Unit>()
+        val core = PendingOverlayCore(
+            initial = dsState,
+            launchWrite = { writeQueue += it },
+            persist = { key, value ->
+                if (firstWrite) {
+                    firstWrite = false
+                    throw java.io.IOException("Disk full on first write")
+                }
+                val mutable = dsState.toMutablePreferences()
+                mutable.setPrefValue(key, value)
+                dsState = mutable.toPreferences()
+                dsState
+            },
+        )
+        // 第一次写入 2 (失败)
+        core.put("k", 2)
+        // 第二次写入 3 (成功)
+        core.put("k", 3)
+
+        assertEquals(3, core.preferencesFlow.value.compatDsInt("k"))
+
+        // 执行第一个任务（失败）
+        try {
+            runBlocking { writeQueue.removeFirst().invoke() }
+        } catch (e: Exception) {
+            // Expected
+        }
+
+        // 此时因为 pending 中最新的 write 对象是 3 的写入，且 3 的任务还没跑完，
+        // 即使 2 的写入任务失败清理了，读取也应该保持最新值 3 (来自 overlay)，而不是回退到 1
+        assertEquals(3, core.preferencesFlow.value.compatDsInt("k"))
+
+        // 执行第二个任务（成功）
+        runBlocking { writeQueue.removeFirst().invoke() }
+
+        // 第二个成功，快照更新为 3，并且 overlay 彻底清空，读取为 3
+        assertEquals(3, core.preferencesFlow.value.compatDsInt("k"))
+        assertEquals(3, dsState.compatDsInt("k"))
+    }
 }

--- a/app/src/test/java/io/legado/app/help/config/PendingOverlayCoreTest.kt
+++ b/app/src/test/java/io/legado/app/help/config/PendingOverlayCoreTest.kt
@@ -1,0 +1,115 @@
+package io.legado.app.help.config
+
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.core.mutablePreferencesOf
+import androidx.datastore.preferences.core.stringPreferencesKey
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * 覆盖 PR-1 合入门禁要求的 pending overlay 三个竞态时序：
+ * 1. 写入后立即读；2. 写入中 collector 回灌旧值；3. 落盘完成后回灌新值。
+ */
+class PendingOverlayCoreTest {
+
+    /** 模拟的 DataStore 落盘状态 + 可手动执行的写队列 */
+    private class Harness(initial: Preferences) {
+        var dsState: Preferences = initial
+        val writeQueue = ArrayDeque<suspend () -> Unit>()
+        val core = PendingOverlayCore(
+            initial = initial,
+            launchWrite = { writeQueue += it },
+            persist = { key, value ->
+                val mutable = dsState.toMutablePreferences()
+                mutable.setPrefValue(key, value)
+                dsState = mutable.toPreferences()
+                dsState
+            },
+        )
+
+        /** 执行队列中下一个落盘任务（模拟 DsSync 串行队列跑完一个 Job） */
+        fun completeNextWrite() = runBlocking { writeQueue.removeFirst().invoke() }
+
+        fun read(key: String): Int? = core.preferencesFlow.value.compatDsInt(key)
+    }
+
+    @Test
+    fun `写入后立即读到新值-落盘尚未发生`() {
+        val h = Harness(mutablePreferencesOf(intPreferencesKey("k") to 1))
+        h.core.put("k", 2)
+        assertEquals(2, h.read("k"))
+        assertEquals(1, h.writeQueue.size)
+    }
+
+    @Test
+    fun `写入中 collector 回灌旧值不覆盖未落盘的新值`() {
+        val h = Harness(mutablePreferencesOf(intPreferencesKey("k") to 1))
+        h.core.put("k", 2)
+        // 落盘未完成时，collector 携带旧状态回灌
+        h.core.onEmission(mutablePreferencesOf(intPreferencesKey("k") to 1))
+        assertEquals(2, h.read("k"))
+        // 其他 key 的回灌内容仍然生效
+        h.core.onEmission(
+            mutablePreferencesOf(
+                intPreferencesKey("k") to 1,
+                intPreferencesKey("other") to 9,
+            )
+        )
+        assertEquals(2, h.read("k"))
+        assertEquals(9, h.read("other"))
+    }
+
+    @Test
+    fun `落盘完成后回灌新值-读取保持新值且 overlay 已清空`() {
+        val h = Harness(mutablePreferencesOf(intPreferencesKey("k") to 1))
+        h.core.put("k", 2)
+        h.completeNextWrite()
+        // 落盘完成即采纳 edit 结果，读取已是新值
+        assertEquals(2, h.read("k"))
+        // collector 随后携带落盘后的新状态回灌
+        h.core.onEmission(h.dsState)
+        assertEquals(2, h.read("k"))
+        // overlay 已清空：此后外部写入（如 Restore）的回灌可正常覆盖
+        h.core.onEmission(mutablePreferencesOf(intPreferencesKey("k") to 5))
+        assertEquals(5, h.read("k"))
+    }
+
+    @Test
+    fun `同 key 连续写入-旧写入落盘不移除新写入的 overlay`() {
+        val h = Harness(mutablePreferencesOf())
+        h.core.put("k", 1)
+        h.core.put("k", 2)
+        assertEquals(2, h.read("k"))
+        // 第一次写入落盘完成，读取仍是第二次写入的值
+        h.completeNextWrite()
+        assertEquals(2, h.read("k"))
+        // 第二次写入落盘完成
+        h.completeNextWrite()
+        assertEquals(2, h.read("k"))
+        assertEquals(2, h.dsState.compatDsInt("k"))
+    }
+
+    @Test
+    fun `移除写入立即隐藏快照中的旧值`() {
+        val h = Harness(mutablePreferencesOf(stringPreferencesKey("k") to "v"))
+        h.core.put("k", null)
+        assertNull(h.core.preferencesFlow.value.compatDsString("k"))
+        h.completeNextWrite()
+        assertNull(h.dsState.rawPrefValue("k"))
+    }
+
+    @Test
+    fun `落盘顺序与提交顺序一致`() {
+        val h = Harness(mutablePreferencesOf())
+        h.core.put("a", 1)
+        h.core.put("b", 2)
+        h.core.put("a", 3)
+        while (h.writeQueue.isNotEmpty()) h.completeNextWrite()
+        assertEquals(3, h.dsState.compatDsInt("a"))
+        assertEquals(2, h.dsState.compatDsInt("b"))
+        assertEquals(h.dsState, h.core.preferencesFlow.value)
+    }
+}

--- a/app/src/test/java/io/legado/app/help/config/PreferencesDsCompatTest.kt
+++ b/app/src/test/java/io/legado/app/help/config/PreferencesDsCompatTest.kt
@@ -1,0 +1,106 @@
+package io.legado.app.help.config
+
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.floatPreferencesKey
+import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.core.longPreferencesKey
+import androidx.datastore.preferences.core.mutablePreferencesOf
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.core.stringSetPreferencesKey
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class PreferencesDsCompatTest {
+
+    @Test
+    fun `按目标类型直接读取`() {
+        val prefs = mutablePreferencesOf(
+            intPreferencesKey("i") to 5,
+            booleanPreferencesKey("b") to true,
+            longPreferencesKey("l") to 7L,
+            floatPreferencesKey("f") to 1.5f,
+            stringPreferencesKey("s") to "hello",
+            stringSetPreferencesKey("set") to setOf("a", "b"),
+        )
+        assertEquals(5, prefs.compatDsInt("i"))
+        assertEquals(true, prefs.compatDsBoolean("b"))
+        assertEquals(7L, prefs.compatDsLong("l"))
+        assertEquals(1.5f, prefs.compatDsFloat("f"))
+        assertEquals("hello", prefs.compatDsString("s"))
+        assertEquals(setOf("a", "b"), prefs.compatDsStringSet("set"))
+    }
+
+    @Test
+    fun `string 形式的历史值可解析为目标类型`() {
+        val prefs = mutablePreferencesOf(
+            stringPreferencesKey("i") to "5",
+            stringPreferencesKey("b") to "true",
+            stringPreferencesKey("l") to "7",
+            stringPreferencesKey("f") to "1.5",
+        )
+        assertEquals(5, prefs.compatDsInt("i"))
+        assertEquals(true, prefs.compatDsBoolean("b"))
+        assertEquals(7L, prefs.compatDsLong("l"))
+        assertEquals(1.5f, prefs.compatDsFloat("f"))
+    }
+
+    @Test
+    fun `int 存储的值可作为 long 与 float 读取`() {
+        val prefs = mutablePreferencesOf(intPreferencesKey("k") to 3)
+        assertEquals(3L, prefs.compatDsLong("k"))
+        assertEquals(3f, prefs.compatDsFloat("k"))
+    }
+
+    @Test
+    fun `缺失或无法解析的值返回 null 而不抛异常`() {
+        val prefs = mutablePreferencesOf(
+            stringPreferencesKey("garbage") to "not a number",
+            intPreferencesKey("wrongType") to 1,
+        )
+        assertNull(prefs.compatDsInt("absent"))
+        assertNull(prefs.compatDsInt("garbage"))
+        assertNull(prefs.compatDsBoolean("garbage"))
+        assertNull(prefs.compatDsBoolean("wrongType"))
+        assertNull(prefs.compatDsString("wrongType"))
+        assertNull(prefs.compatDsStringSet("garbage"))
+    }
+
+    @Test
+    fun `boolean 解析大小写严格`() {
+        val prefs = mutablePreferencesOf(stringPreferencesKey("b") to "True")
+        assertNull(prefs.compatDsBoolean("b"))
+    }
+
+    @Test
+    fun `setPrefValue 覆盖同名旧类型条目`() {
+        val prefs = mutablePreferencesOf(stringPreferencesKey("k") to "1")
+        prefs.setPrefValue("k", 2)
+        assertEquals(2, prefs.compatDsInt("k"))
+        assertNull(prefs.compatDsString("k"))
+    }
+
+    @Test
+    fun `setPrefValue null 移除任意类型条目`() {
+        val prefs = mutablePreferencesOf(intPreferencesKey("k") to 1)
+        prefs.setPrefValue("k", null)
+        assertNull(prefs.rawPrefValue("k"))
+    }
+
+    @Test
+    fun `setPrefValue 写入各类型`() {
+        val prefs = mutablePreferencesOf()
+        prefs.setPrefValue("s", "v")
+        prefs.setPrefValue("i", 1)
+        prefs.setPrefValue("b", true)
+        prefs.setPrefValue("l", 2L)
+        prefs.setPrefValue("f", 3f)
+        prefs.setPrefValue("set", setOf("x"))
+        assertEquals("v", prefs.compatDsString("s"))
+        assertEquals(1, prefs.compatDsInt("i"))
+        assertEquals(true, prefs.compatDsBoolean("b"))
+        assertEquals(2L, prefs.compatDsLong("l"))
+        assertEquals(3f, prefs.compatDsFloat("f"))
+        assertEquals(setOf("x"), prefs.compatDsStringSet("set"))
+    }
+}

--- a/app/src/test/java/io/legado/app/help/config/PreferencesDsCompatTest.kt
+++ b/app/src/test/java/io/legado/app/help/config/PreferencesDsCompatTest.kt
@@ -56,14 +56,41 @@ class PreferencesDsCompatTest {
     fun `缺失或无法解析的值返回 null 而不抛异常`() {
         val prefs = mutablePreferencesOf(
             stringPreferencesKey("garbage") to "not a number",
-            intPreferencesKey("wrongType") to 1,
         )
         assertNull(prefs.compatDsInt("absent"))
         assertNull(prefs.compatDsInt("garbage"))
         assertNull(prefs.compatDsBoolean("garbage"))
-        assertNull(prefs.compatDsBoolean("wrongType"))
-        assertNull(prefs.compatDsString("wrongType"))
         assertNull(prefs.compatDsStringSet("garbage"))
+    }
+
+    @Test
+    fun `增强的类型转换测试`() {
+        val prefs = mutablePreferencesOf(
+            intPreferencesKey("i1") to 1,
+            intPreferencesKey("i0") to 0,
+            intPreferencesKey("i9") to 9,
+            stringPreferencesKey("s1") to "1",
+            stringPreferencesKey("s0") to "0",
+            booleanPreferencesKey("b") to true,
+            floatPreferencesKey("f") to 3.14f
+        )
+        // Number/Boolean to String
+        assertEquals("1", prefs.compatDsString("i1"))
+        assertEquals("true", prefs.compatDsString("b"))
+        assertEquals("3.14", prefs.compatDsString("f"))
+
+        // Float/Double/Long/Int to Boolean
+        assertEquals(true, prefs.compatDsBoolean("i1"))
+        assertEquals(false, prefs.compatDsBoolean("i0"))
+        assertNull(prefs.compatDsBoolean("i9"))
+
+        // String "1"/"0" to Boolean
+        assertEquals(true, prefs.compatDsBoolean("s1"))
+        assertEquals(false, prefs.compatDsBoolean("s0"))
+
+        // Float to Long/Int
+        assertEquals(3, prefs.compatDsInt("f"))
+        assertEquals(3L, prefs.compatDsLong("f"))
     }
 
     @Test
@@ -77,7 +104,7 @@ class PreferencesDsCompatTest {
         val prefs = mutablePreferencesOf(stringPreferencesKey("k") to "1")
         prefs.setPrefValue("k", 2)
         assertEquals(2, prefs.compatDsInt("k"))
-        assertNull(prefs.compatDsString("k"))
+        assertEquals("2", prefs.compatDsString("k"))
     }
 
     @Test

--- a/app/src/test/java/io/legado/app/help/storage/NormalizeConfigMapTest.kt
+++ b/app/src/test/java/io/legado/app/help/storage/NormalizeConfigMapTest.kt
@@ -1,0 +1,119 @@
+package io.legado.app.help.storage
+
+import io.legado.app.constant.PreferKey
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+class NormalizeConfigMapTest {
+
+    private fun normalize(
+        map: Map<String, Any?>,
+        keyIsNotIgnore: (String) -> Boolean = { true },
+        decryptWebDavPassword: (String) -> String? = { null },
+        hasLocalWebDavPassword: Boolean = false,
+    ) = normalizeConfigMap(map, keyIsNotIgnore, decryptWebDavPassword, hasLocalWebDavPassword)
+
+    @Test
+    fun `基础类型原样保留且跳过 null`() {
+        val result = normalize(
+            mapOf(
+                "int" to 1,
+                "boolean" to true,
+                "long" to 2L,
+                "float" to 3f,
+                "string" to "s",
+                "nullKey" to null,
+            )
+        )
+        assertEquals(
+            mapOf("int" to 1, "boolean" to true, "long" to 2L, "float" to 3f, "string" to "s"),
+            result
+        )
+    }
+
+    @Test
+    fun `Double 转为 Float`() {
+        val result = normalize(mapOf("fontScale" to 1.5))
+        assertEquals(1.5f, result["fontScale"])
+    }
+
+    @Test
+    fun `忽略键被过滤`() {
+        val result = normalize(
+            mapOf("keep" to 1, "drop" to 2),
+            keyIsNotIgnore = { it != "drop" },
+        )
+        assertEquals(mapOf("keep" to 1), result)
+    }
+
+    @Test
+    fun `webDavPassword 解密成功用解密值`() {
+        val result = normalize(
+            mapOf(PreferKey.webDavPassword to "encrypted"),
+            decryptWebDavPassword = { if (it == "encrypted") "plain" else null },
+            hasLocalWebDavPassword = true,
+        )
+        assertEquals("plain", result[PreferKey.webDavPassword])
+    }
+
+    @Test
+    fun `webDavPassword 解密失败且本地无密码时保留原文`() {
+        val result = normalize(
+            mapOf(PreferKey.webDavPassword to "rawPassword"),
+            decryptWebDavPassword = { null },
+            hasLocalWebDavPassword = false,
+        )
+        assertEquals("rawPassword", result[PreferKey.webDavPassword])
+    }
+
+    @Test
+    fun `webDavPassword 解密失败且本地已有密码时丢弃`() {
+        val result = normalize(
+            mapOf(PreferKey.webDavPassword to "rawPassword"),
+            decryptWebDavPassword = { null },
+            hasLocalWebDavPassword = true,
+        )
+        assertFalse(result.containsKey(PreferKey.webDavPassword))
+    }
+
+    @Test
+    fun `旧版 bookInfoBackgroundBlur 补写两个新背景键`() {
+        val result = normalize(mapOf(PreferKey.bookInfoBackgroundBlur to "blur"))
+        assertEquals("blur", result[PreferKey.bookInfoBackgroundBlur])
+        assertEquals("blur", result[PreferKey.bookInfoNetworkCoverBackground])
+        assertEquals("blur", result[PreferKey.bookInfoDefaultCoverBackground])
+    }
+
+    @Test
+    fun `备份已含新背景键时不覆盖`() {
+        val result = normalize(
+            mapOf(
+                PreferKey.bookInfoBackgroundBlur to "blur",
+                PreferKey.bookInfoNetworkCoverBackground to "network",
+            )
+        )
+        assertEquals("network", result[PreferKey.bookInfoNetworkCoverBackground])
+        assertEquals("blur", result[PreferKey.bookInfoDefaultCoverBackground])
+    }
+
+    @Test
+    fun `新背景键被忽略时不补写`() {
+        val result = normalize(
+            mapOf(PreferKey.bookInfoBackgroundBlur to "blur"),
+            keyIsNotIgnore = { it != PreferKey.bookInfoDefaultCoverBackground },
+        )
+        assertEquals("blur", result[PreferKey.bookInfoNetworkCoverBackground])
+        assertFalse(result.containsKey(PreferKey.bookInfoDefaultCoverBackground))
+    }
+
+    @Test
+    fun `bookInfoBackgroundBlur 本身被忽略时不拆键`() {
+        val result = normalize(
+            mapOf(PreferKey.bookInfoBackgroundBlur to "blur"),
+            keyIsNotIgnore = { it != PreferKey.bookInfoBackgroundBlur },
+        )
+        assertFalse(result.containsKey(PreferKey.bookInfoNetworkCoverBackground))
+        assertFalse(result.containsKey(PreferKey.bookInfoDefaultCoverBackground))
+    }
+}


### PR DESCRIPTION
# PR 描述：存储收敛与免重启改造（SP 退役与重建机制演进）

本 PR 完成了项目从 SharedPreferences（SP）向 DataStore 迁移的收尾。建立了内存快照层（Pending Overlay）作为配置读写缓冲，切断了全局 `settings` 域的 SP 写入；"语言切换"改为 AppCompat per-app locales 免重启生效，"主题包应用"与"预测性返回开关"改为 Compose 响应式即时生效（零重建），以消除主线程 IO 阻塞与不必要的应用冷启动。

---

## 1. 解决的问题与背景（Why?）

### 1.1 重构前方案架构与时序缺陷

在原先的过渡期双写方案中，`PrefDelegate` 同时分发写入 SP 和 DataStore，并且读端在没有快照层的情况下，在主线程频繁通过 `runBlocking` 强制同步挂起 DataStore。

#### 重构前的模块依赖关系
```mermaid
graph TD
    subgraph UI 消费层
        A["UI / Settings (get/set)"]
    end

    subgraph 双写代理层
        B["PrefDelegate (委托代理)"]
    end

    subgraph 持久化层
        C["SharedPreferences (SP 物理写入)"]
        D["DataStore (磁盘 preferences_pb)"]
    end

    A -->|1. setter| B
    B -->|2. apply| C
    B -->|3. 异步 edit 协程| D

    A -->|"4. getter (runBlocking 阻塞读)"| D

    style D fill:#fdd,stroke:#333,stroke-width:2px
```

### 1.2 暴露的技术痛点
1. **双写一致性问题**：双写与双异步落盘在特定时序下会导致"设置后立即重启丢设置"。
2. **主线程 IO 阻塞**：`AppConfig` 中多处在主线程通过 `runBlocking` 同步等待 DataStore，造成读写配置时主线程卡顿与 ANR 隐患。
3. **冷启动与未即时刷新**：切换语言时执行 `Process.killProcess` 强杀进程冷启动，后台阅读进度与草稿丢失；应用主题包、切换预测性返回开关时只能提示"重启生效"。

---

## 2. 重构后架构设计（How?）

### 2.1 模块依赖关系拓扑
```mermaid
graph TD
    subgraph "UI 消费层 (直读内存)"
        A["BaseActivity / BaseComposeActivity (Theme / Font)"]
        B["ReadBookMenuBar (阅读设置)"]
        C["Settings / Config Screens"]
    end

    subgraph "内存快照与缓冲层 (AppConfigStore)"
        D["preferences (Preferences Flow - 内存快照)"]
        E["pending (LinkedHashMap - 未确认写入缓冲)"]
    end

    subgraph "异步串行持久化 (DsSync)"
        F["writeDispatcher (单线程调度 limitedParallelism)"]
        G["settings.preferences_pb (DataStore 持久化文件)"]
    end

    A & B & C -->|getPref* 门面读取| D
    B & C -->|putPref* 写入| E
    E -->|launchWrite 串行排队| F
    F -->|measureTime 监控| G
    G -->|collector 回灌确认| D

    style D fill:#f9f,stroke:#333,stroke-width:2px
    style E fill:#bbf,stroke:#333,stroke-width:2px
```

### 2.2 "写后立即读"时序交互
```mermaid
sequenceDiagram
    autonumber
    actor UI as UI 线程
    participant Store as AppConfigStore
    participant Core as PendingOverlayCore
    participant Queue as DsSync (单线程队列)
    participant Disk as DataStore (磁盘)

    UI->>Store: 1. putPrefString("key", "Value_New")
    Store->>Core: 2. lock { pending["key"] = write } 并 rebuild()
    Note over Core: 内存覆盖立即生效：读侧优先返回 pending
    Store->>Queue: 3. launchWrite(write)
    Store-->>UI: 4. 同步返回（写入内存即生效）

    Queue->>Disk: 5. dataStore.edit { ... }
    Disk-->>Queue: 6. 磁盘写入完成（pending 暂不移除）

    Disk->>Core: 7. collector 回灌落盘后的新状态 (onEmission)
    Note over Core: 回灌中该 key 的值已等于写入目标值<br/>确认落盘已对 collector 可见
    Core->>Core: 8. 确认一致，移除 overlay 并采纳 snapshot
```

---

## 3. 核心机制技术解析

### 3.1 内存快照层与 Pending Overlay 读写路径
不再通过 `runBlocking` 直接去磁盘拉取数据。`Application.onCreate` 首行同步一次性读取 DataStore 缓存为内存快照，此后读取完全在内存中同步完成，彻底移除 `runBlocking`。

`PendingOverlayCore` 维护不变式：**对外可见状态 = snapshot 叠加所有 pending 写入，pending 永远优先**。
* **写路径**：`putPref*` 将新值写入 `pending` 使内存立刻可见，随即经 `DsSync.launchWrite` 串行异步落盘。
* **读路径**：读取合成后的状态流（StateFlow），pending 中存在的 key 直接命中新值，否则回落到已落盘的 snapshot。

### 3.2 Overlay 清理机制（回灌确认后移除，解决并发落盘与旧回灌竞态）
snapshot 只由 DataStore collector 回灌（`onEmission`）单调推进；pending 条目要等到**回灌中该 key 的值已等于写入目标值**时才移除。

* **为什么不能在落盘完成时立即移除**：
  落盘完成后，collector 可能才处理到一条落盘前排队的旧回灌。若此时 pending 已被移除，snapshot 被旧状态覆盖会让读值短暂回滚——`observe` 订阅方会收到"新→旧→新"的幻影变更，引发多余的 Activity recreate、WebDav refresh 与 UI 闪烁。
* **解决方法**：
  ```kotlin
  fun onEmission(prefs: Preferences) {
      synchronized(lock) {
          snapshot = prefs
          // 回灌已包含 pending 写入的目标值时，说明该写入已落盘且对 collector 可见
          pending.entries.removeAll { (key, write) -> prefs.rawPrefValue(key) == write.value }
          rebuild()
      }
  }
  ```
  旧回灌到达时，未确认的 pending 仍作为"保护盾"叠加在 snapshot 之上，读值不会回退。
* **失败回滚与同 key 覆盖**：落盘失败时按引用判等（`pending[key] === write` 成立才移除）回滚到已落盘状态并记录错误日志；同 key 已有更新写入时不移除，由新条目继续覆盖，保证高并发下 Overlay 永远指向最新修改。

### 3.3 类型兼容解析（PreferencesDsCompat）
历史数据中同 key 存在不同写入类型（int 存成 "1"、long 存成 int 等），强转会抛 `ClassCastException`。类型安全读取层：

```kotlin
// Key 按 name 判等，用 string 类型的 key 即可取到该 name 下任意类型的原始值；
// 返回位置声明为 Any?，编译器不插入 checkcast。不可用 asMap() 实现：
// datastore 的 asMap() 每次调用都会全量复制 map，而读取是热路径
fun Preferences.rawPrefValue(key: String): Any? = this[stringPreferencesKey(key)]
```

取到原始值后按期望类型自适应降级解析（`String`↔`Boolean`、数值互转、"1"/"0" 兼容等），底层物理类型混乱时也能安全读取不崩溃。

### 3.4 落盘等待机制（解决杀进程设置丢失）
强杀或重启前，必须确保排队中的写入已物理落盘：

1. 落盘协程调度器限制为单线程（`Dispatchers.IO.limitedParallelism(1)`），所有写入按提交顺序绝对串行；`AtomicInteger` 计数在任务入队前同步递增。
2. `restart()` 前阻塞等待计数归零（带超时兜底）：
   ```kotlin
   suspend fun awaitPendingWrites(timeoutMs: Long = 3000) {
       withTimeoutOrNull(timeoutMs) {
           while (pendingCount.get() > 0) delay(50)
       }
   }
   ```
   计数在 `launchWrite` 返回前已递增，因此"写入门面调用返回 → awaitPendingWrites"之间不存在漏计窗口。

---

## 4. 改动细节与模块重构

### 4.1 移除旧 SP 物理写入通道（SP 退役）
* 门面 `putPref*` / `removePref` 在快照初始化后仅写入快照与 DataStore 落盘队列，移除 `defaultSharedPreferences.edit` 写入（保留未初始化阶段的冷启动降级兜底）。
* `PrefDelegate` 移除失效的 `sync` 参数；`putPrefStringSync` 别名与 `DsSync` 旁路写入 API 一并清理。
* Restore 恢复配置改走 `AppConfigStore.putAll` 批量 overlay 写入（单次 edit 落盘），恢复后立即读不再依赖 collector 回灌时机。

### 4.2 去监听器，改 Flow 订阅（AppConfig 优化）
* 删除 `AppConfig` 的 `OnSharedPreferenceChangeListener`，缓存字段退化为直读快照的计算属性。
* `WebDavManager` 与 `BaseReadAloudService` 改用 `AppConfigStore.observe*` Flow 订阅；各 key 独立 `drop(1)` 跳过 StateFlow 初始回放，`WebDavManager` 额外 `debounce(100)` 合并连续变更。

### 4.3 免重启生效机制
* **语言切换免重启**：
  * `AppCompatDelegate.setApplicationLocales(localeList)` 免重启秒切语言，框架自动重建相关 Activity，`onSaveInstanceState` 保证阅读进度与草稿保留。
  * `AndroidManifest.xml` 配置 `android:autoStoreLocales="true"` 与 `AppLocalesMetadataHolderService`，兼容 API < 33。
  * 旧版语言偏好在 App.onCreate 以 `LocalConfig` 标记做**一次性**迁移写入 per-app locales，之后交由 autoStoreLocales 持久化（避免 API < 33 每次冷启动重复执行、API 33+ 覆盖用户在系统设置里的选择）。
  * 移除 Activity 基类的 locale 手动覆盖逻辑。
* **主题包应用与预测性返回开关即时生效（零重建）**：
  * Compose 主题（`AppTheme`）对全部主题键为组合内状态读取，主题包应用/导入写入即全局生效；预测性返回开关的消费点（`BackHandler(enabled)` / `predictivePopTransitionSpec`）同为响应式读取，切换即时生效且不打断开关动画。
  * 仅当 `fontScale`、自定义颜色、背景图、对比度等确需重建的键实际变化时，由各自 `prefDelegate` 既有的 `RECREATE` 回调按需触发一次原地重建；未变化则零重建。

### 4.4 写入性能监测
* `AtomicInteger` 追踪排队任务数；单次 `edit` 耗时超过 500ms 时打印警告日志。

---

## 5. 修改文件清单

* **AndroidManifest.xml**：注册 AppCompat 自动存储 locales 服务。
* **App.kt**：onCreate 首行初始化快照；语言偏好一次性迁移；删除 SP 监听器注册与 postMigrationSync。
* **AppConfigStore.kt / PreferencesDsCompat.kt** [NEW]：内存快照层（含 `putAll` 批量写入）与类型安全解析。
* **DsSync.kt** [NEW]：串行落盘队列、`awaitPendingWrites`、慢写入监控。
* **AppConfig.kt**：删除 SP 监听器；缓存字段退化为读快照；移除 5 处 `runBlocking` 直读。
* **SettingsRepository.kt**：删除向 SP 回灌的 `postMigrationSync` 及 `remove` 中的 SP 写入。
* **AppContextWrapper.kt / BaseActivity.kt / BaseComposeActivity.kt**：移除手动 locale 包装，保留 fontScale。
* **WebDavManager.kt / BaseReadAloudService.kt**：SP 监听重构为 Flow 订阅。
* **Restore.kt**：恢复改走 `AppConfigStore.putAll`；按恢复的语言偏好应用 per-app locales。
* **LocalConfig.kt / OtherConfig.kt / OtherConfigScreen.kt**：一次性迁移标记；语言→Locale 映射抽取为 `appLocaleListFor` 复用。
* **ThemeConfig.kt / ThemeConfigScreen.kt / ThemeManageScreen.kt / ThemeManageViewModel.kt**：预测性返回与主题包应用改为 Compose 响应式即时生效，移除重启弹窗与无条件全局重建。
* **PendingOverlayCoreTest.kt / PreferencesDsCompatTest.kt** [NEW]：覆盖写后立即读、旧回灌不回滚、落盘失败回滚、同 key 并发覆盖、批量写入、类型错乱降级等时序与兼容用例。

---

## 6. 验证表现

### 6.1 已通过真机手测验证
1. **冷启动与闪烁**：开启"不保留活动"后杀进程冷启动，首屏无闪烁，冷启动耗时无明显差异。
2. **切语言重建**：切换语言全界面动态重建并应用，Activity 栈与草稿保留。
3. **主题与手势即时应用**：应用主题包、切换预测性返回开关即时生效，开关动画完整，无多余重建。
4. **设置滑条**：快速拖动无读值回滚/闪烁。
5. **恢复备份**：语言等配置随备份即时生效（应用图标属设备本地配置，按既有设计不参与备份）。

### 6.2 逻辑已在单测中闭环
1. **写后立即读 / 旧回灌不回滚 / 落盘失败回滚 / 同 key 并发覆盖 / 批量写入确认**：`PendingOverlayCoreTest` 全覆盖。
2. **WebView 重置安全**：`awaitPendingWrites` 在 3000ms 超时内保证落盘后再重启进程。

---

## 7. 审查修复记录

* 快照回滚竞态：落盘成功不再立即清 pending，改为回灌确认后移除（见 3.2）
* 读路径性能：`rawPrefValue` 弃用 `asMap()`（datastore 每次调用全量复制 map），改单 key 直取（见 3.3）
* Restore 恢复配置改走 `AppConfigStore.putAll`，消除恢复后立即读的时序依赖
* 语言偏好迁移一次性化（`LocalConfig` 标记）
* 预测性返回开关与主题包应用移除多余的全局 RECREATE，改为响应式即时生效（见 4.3）
* 清理：`DsSync` 旁路写入 API、`prefDelegate` 失效的 `sync` 参数、`putPrefStringSync` 别名