### PR TITLE
fix:阅读界面切换深浅后状态栏显示的问题

### DIFF
--- a/app/src/main/java/io/legado/app/ui/book/read/ReadBookViewModel.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/ReadBookViewModel.kt
@@ -5521,7 +5521,6 @@ class ReadBookViewModel(
                 ConfigUpdateAction.UpdateSystemUi
             )
         ))
-        postEvent(EventBus.UPDATE_READ_ACTION_BAR, true)
     }
 
     private fun applyReadStyleBackgroundImage(uri: Uri) {

--- a/app/src/main/java/io/legado/app/ui/main/MainActivity.kt
+++ b/app/src/main/java/io/legado/app/ui/main/MainActivity.kt
@@ -47,6 +47,7 @@ import io.legado.app.service.WebService
 import io.legado.app.ui.about.CrashLogsDialog
 import io.legado.app.ui.about.UpdateDialog
 import io.legado.app.ui.book.read.ReadBookInputHandler
+import io.legado.app.ui.book.read.ReadBookRouteHost
 import io.legado.app.ui.book.read.page.entities.PageDirection
 import io.legado.app.ui.config.otherConfig.OtherConfig
 import io.legado.app.ui.config.themeConfig.ThemeConfig
@@ -502,6 +503,15 @@ open class MainActivity : BaseComposeActivity(), VariableDialog.Callback {
     override fun onKeyUp(keyCode: Int, event: KeyEvent): Boolean {
         if (activeReadBookInputHandler?.onKeyUp(keyCode, event) == true) return true
         return super.onKeyUp(keyCode, event)
+    }
+
+    override fun setupSystemBar() {
+        val host = activeReadBookInputHandler as? ReadBookRouteHost
+        if (host != null) {
+            host.upSystemUiVisibility()
+        } else {
+            super.setupSystemBar()
+        }
     }
 
     override fun onDestroy() {


### PR DESCRIPTION
- BaseComposeActivity的onConfigurationChanged调用了setupSystemBar，即使阅读界面隐藏了状态栏，也会被toggleSystemBar(AppConfig.showStatusBar)方法显示