### PR TITLE
refactor (read & typography): 清理废弃功能并规范化排版配置键名

### DIFF
--- a/app/src/main/java/io/legado/app/ui/book/read/ReadBookMenuBar.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/ReadBookMenuBar.kt
@@ -711,9 +711,6 @@ private fun ReadBookMenuSurface(
                                 onOpenUnderlineConfig = {
                                     onIntent(ReadBookIntent.ShowSheet(ReadBookSheet.UnderlineConfig))
                                 },
-                                onOpenShadowSet = {
-                                    onIntent(ReadBookIntent.ShowSheet(ReadBookSheet.ShadowSet))
-                                },
                                 onOpenFontSelect = {
                                     onIntent(ReadBookIntent.ShowSheet(ReadBookSheet.FontSelect))
                                 },

--- a/app/src/main/java/io/legado/app/ui/book/read/sheet/GlobalThemePage.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/sheet/GlobalThemePage.kt
@@ -25,10 +25,8 @@ import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.DarkMode
 import androidx.compose.material.icons.filled.FormatUnderlined
 import androidx.compose.material.icons.filled.GridView
-import androidx.compose.material.icons.filled.Layers
 import androidx.compose.material.icons.filled.LightMode
 import androidx.compose.material.icons.filled.Tablet
-import androidx.compose.material.icons.filled.Translate
 import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material3.Icon
 import androidx.compose.material3.PlainTooltip
@@ -80,7 +78,6 @@ fun GlobalThemePage(
     eyeProtectionEnabled: Boolean,
     onOpenBgTextConfig: (Int) -> Unit,
     onOpenUnderlineConfig: () -> Unit,
-    onOpenShadowSet: () -> Unit,
     onShareLayoutChange: (Boolean) -> Unit,
     onStyleSelect: (Int) -> Unit,
     modifier: Modifier = Modifier,
@@ -94,7 +91,6 @@ fun GlobalThemePage(
     val styleSelect = styleConfig.styleSelect
     val shareLayout = styleConfig.shareLayout
     val isNightTheme = LegadoTheme.isDark
-    val chineseConverterType = preferences.chineseConverterType
     val doubleHorizontalPage = preferences.doubleHorizontalPage
 
     val configList = styleConfig.styleItems
@@ -133,25 +129,6 @@ fun GlobalThemePage(
                     Icon(
                         imageVector = Icons.Default.FormatUnderlined,
                         contentDescription = stringResource(R.string.use_underline),
-                        tint = LegadoTheme.colorScheme.onSurfaceVariant
-                    )
-                }
-            }
-            NormalCard(
-                onClick = onOpenShadowSet,
-                modifier = Modifier
-                    .height(56.dp)
-                    .aspectRatio(1f),
-                containerColor = LegadoTheme.colorScheme.surfaceContainerLow,
-                cornerRadius = 12.dp
-            ) {
-                Box(
-                    contentAlignment = Alignment.Center,
-                    modifier = Modifier.fillMaxSize(),
-                ) {
-                    Icon(
-                        imageVector = Icons.Default.Layers,
-                        contentDescription = stringResource(R.string.text_shadow_set),
                         tint = LegadoTheme.colorScheme.onSurfaceVariant
                     )
                 }
@@ -380,56 +357,6 @@ fun GlobalThemePage(
                             onClick = {
                                 ReadBook.book?.setPageAnim(-1)
                                 onIntent(ReadBookIntent.UpdateConfig(ConfigUpdate.PageAnim(index)))
-                                dismiss()
-                            },
-                        )
-                    }
-                }
-            }
-            // 中文简繁互转 — dropdown menu
-            Box {
-                var showChineseConvertMenu by remember { mutableStateOf(false) }
-                val chineseConvertEntries = stringArrayResource(R.array.chinese_mode)
-                val chineseConvertValues = remember { arrayOf("0", "1", "2") }
-                NormalCard(
-                    onClick = { showChineseConvertMenu = true },
-                    modifier = Modifier
-                        .height(56.dp)
-                        .aspectRatio(1f),
-                    containerColor = if (chineseConverterType > 0) {
-                        LegadoTheme.colorScheme.secondaryContainer
-                    } else {
-                        LegadoTheme.colorScheme.surfaceContainerLow
-                    },
-                    cornerRadius = 12.dp
-                ) {
-                    Box(
-                        contentAlignment = Alignment.Center,
-                        modifier = Modifier.fillMaxSize(),
-                    ) {
-                        Icon(
-                            imageVector = Icons.Default.Translate,
-                            contentDescription = stringResource(R.string.chinese_converter),
-                            tint = if (chineseConverterType > 0) {
-                                LegadoTheme.colorScheme.onSecondaryContainer
-                            } else {
-                                LegadoTheme.colorScheme.onSurfaceVariant
-                            }
-                        )
-                    }
-                }
-                RoundDropdownMenu(
-                    expanded = showChineseConvertMenu,
-                    onDismissRequest = { showChineseConvertMenu = false },
-                ) { dismiss ->
-                    chineseConvertEntries.forEachIndexed { index, display ->
-                        RoundDropdownMenuItem(
-                            text = display,
-                            isSelected = chineseConvertValues[index] == chineseConverterType.toString(),
-                            onClick = {
-                                onIntent(ReadBookIntent.UpdateConfig(
-                                    ConfigUpdate.ChineseConverterType(chineseConvertValues[index].toInt())
-                                ))
                                 dismiss()
                             },
                         )

--- a/app/src/main/java/io/legado/app/ui/book/read/sheet/ReadStyleSheet.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/sheet/ReadStyleSheet.kt
@@ -42,7 +42,6 @@ fun ReadStyleContent(
     onOpenMoreConfig: () -> Unit,
     onOpenBgTextConfig: (Int) -> Unit,
     onOpenUnderlineConfig: () -> Unit,
-    onOpenShadowSet: () -> Unit,
     onOpenFontSelect: () -> Unit,
     onToggleDayNight: () -> Unit,
     onPageChanged: (Int) -> Unit = {},
@@ -98,7 +97,6 @@ fun ReadStyleContent(
                         eyeProtectionEnabled = eyeProtectionEnabled,
                         onOpenBgTextConfig = onOpenBgTextConfig,
                         onOpenUnderlineConfig = onOpenUnderlineConfig,
-                        onOpenShadowSet = onOpenShadowSet,
                         onShareLayoutChange = { shareLayout ->
                             onIntent(ReadBookIntent.UpdateConfig(ConfigUpdate.ShareLayout(shareLayout)))
                         },

--- a/app/src/main/java/io/legado/app/ui/book/read/sheet/TypographyTabs.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/sheet/TypographyTabs.kt
@@ -14,12 +14,37 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AlignHorizontalCenter
+import androidx.compose.material.icons.filled.AlignHorizontalLeft
+import androidx.compose.material.icons.filled.AlignHorizontalRight
+import androidx.compose.material.icons.filled.AspectRatio
+import androidx.compose.material.icons.filled.CallSplit
 import androidx.compose.material.icons.filled.CleanHands
+import androidx.compose.material.icons.filled.Code
+import androidx.compose.material.icons.filled.CopyAll
+import androidx.compose.material.icons.filled.FormatAlignJustify
+import androidx.compose.material.icons.filled.FormatColorText
+import androidx.compose.material.icons.filled.FormatIndentIncrease
 import androidx.compose.material.icons.filled.FormatItalic
+import androidx.compose.material.icons.filled.FormatLineSpacing
+import androidx.compose.material.icons.filled.FormatSize
 import androidx.compose.material.icons.filled.FormatUnderlined
+import androidx.compose.material.icons.filled.Height
+import androidx.compose.material.icons.filled.Image
 import androidx.compose.material.icons.filled.Layers
+import androidx.compose.material.icons.filled.LineWeight
+import androidx.compose.material.icons.filled.Minimize
+import androidx.compose.material.icons.filled.Palette
+import androidx.compose.material.icons.filled.Segment
+import androidx.compose.material.icons.filled.SpaceBar
 import androidx.compose.material.icons.filled.TextFields
+import androidx.compose.material.icons.filled.Title
+import androidx.compose.material.icons.filled.Translate
 import androidx.compose.material.icons.filled.Tune
+import androidx.compose.material.icons.filled.VerticalAlignBottom
+import androidx.compose.material.icons.filled.VerticalAlignTop
+import androidx.compose.material.icons.filled.ViewAgenda
+import androidx.compose.material.icons.filled.ViewHeadline
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
@@ -29,6 +54,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringArrayResource
 import androidx.compose.ui.res.stringResource
@@ -113,6 +139,7 @@ private fun FontWeightSetting(
                     selectedValue = value.toString(),
                     displayEntries = arrayOf(weightEntries[2], weightEntries[0], weightEntries[1]),
                     entryValues = arrayOf("2", "0", "1"),
+                    imageVector = Icons.Default.LineWeight,
                     onValueChange = { onValueChange(it.toInt()) },
                 )
             }
@@ -173,6 +200,7 @@ private fun TipPositionDropdown(
     value: Int,
     tipNames: List<String>,
     tipValues: Array<Int>,
+    imageVector: ImageVector? = null,
     onValueChange: (Int) -> Unit,
 ) {
     TinyDropdownSettingItem(
@@ -180,6 +208,7 @@ private fun TipPositionDropdown(
         selectedValue = value.toString(),
         displayEntries = tipNames.toTypedArray(),
         entryValues = tipValues.map { it.toString() }.toTypedArray(),
+        imageVector = imageVector,
         onValueChange = { onValueChange(it.toInt()) },
     )
 }
@@ -199,24 +228,28 @@ private fun PaddingSliders(
         title = stringResource(R.string.padding_top),
         value = top,
         valueRange = 0f..200f,
+        imageVector = Icons.Default.VerticalAlignTop,
         onValueChange = onTopChange,
     )
     TinySliderSettingItem(
         title = stringResource(R.string.padding_bottom),
         value = bottom,
         valueRange = 0f..200f,
+        imageVector = Icons.Default.VerticalAlignBottom,
         onValueChange = onBottomChange,
     )
     TinySliderSettingItem(
         title = stringResource(R.string.padding_left),
         value = left,
         valueRange = 0f..200f,
+        imageVector = Icons.Default.AlignHorizontalLeft,
         onValueChange = onLeftChange,
     )
     TinySliderSettingItem(
         title = stringResource(R.string.padding_right),
         value = right,
         valueRange = 0f..200f,
+        imageVector = Icons.Default.AlignHorizontalRight,
         onValueChange = onRightChange,
     )
 }
@@ -278,6 +311,7 @@ internal fun TypographyBodyTab(
             selectedValue = config.chineseConverterType.toString(),
             displayEntries = chineseConvertEntries,
             entryValues = chineseConvertValues,
+            imageVector = Icons.Default.Translate,
             onValueChange = {
                 onIntent(ReadBookIntent.UpdateConfig(ConfigUpdate.ChineseConverterType(it.toInt())))
             },
@@ -288,11 +322,13 @@ internal fun TypographyBodyTab(
         TinyColorSettingItem(
             title = stringResource(R.string.text_color),
             colorValue = config.textColor,
+            imageVector = Icons.Default.FormatColorText,
             onClick = { onOpenColorPicker(TypographyColorTarget.Text) },
         )
         TinyColorSettingItem(
             title = stringResource(R.string.text_accent_color),
             colorValue = config.textAccentColor,
+            imageVector = Icons.Default.Palette,
             onClick = { onOpenColorPicker(TypographyColorTarget.TextAccent) },
         )
 
@@ -324,6 +360,7 @@ internal fun TypographyBodyTab(
             value = indentCount.toFloat(),
             valueRange = 0f..4f,
             steps = 3,
+            imageVector = Icons.Default.FormatIndentIncrease,
             onValueChange = { value ->
                 indentCount = value.toInt()
                 onIntent(ReadBookIntent.UpdateConfig(ConfigUpdate.ParagraphIndent("　".repeat(indentCount))))
@@ -334,6 +371,7 @@ internal fun TypographyBodyTab(
             value = (letterSpacing * 100) + 50,
             valueRange = 0f..100f,
             steps = 99,
+            imageVector = Icons.Default.SpaceBar,
             valueFormat = { ((it - 50) / 100f).toString() },
             onValueChange = { value ->
                 letterSpacing = (value - 50) / 100f
@@ -345,6 +383,7 @@ internal fun TypographyBodyTab(
             value = lineSpacing,
             valueRange = 0f..20f,
             steps = 19,
+            imageVector = Icons.Default.FormatLineSpacing,
             valueFormat = { ((it - 10) / 10f).toString() },
             onValueChange = { value ->
                 lineSpacing = value
@@ -356,6 +395,7 @@ internal fun TypographyBodyTab(
             value = paragraphSpacing,
             valueRange = 0f..20f,
             steps = 19,
+            imageVector = Icons.Default.Segment,
             valueFormat = { (it / 10f).toString() },
             onValueChange = { value ->
                 paragraphSpacing = value
@@ -368,6 +408,7 @@ internal fun TypographyBodyTab(
         TinySwitchSettingItem(
             title = stringResource(R.string.text_full_justify),
             checked = config.textFullJustify,
+            imageVector = Icons.Default.FormatAlignJustify,
             onCheckedChange = {
                 onIntent(ReadBookIntent.UpdateConfig(ConfigUpdate.TextFullJustify(it)))
             },
@@ -375,6 +416,7 @@ internal fun TypographyBodyTab(
         TinySwitchSettingItem(
             title = stringResource(R.string.text_bottom_justify),
             checked = config.textBottomJustify,
+            imageVector = Icons.Default.VerticalAlignBottom,
             onCheckedChange = {
                 onIntent(ReadBookIntent.UpdateConfig(ConfigUpdate.TextBottomJustify(it)))
             },
@@ -399,6 +441,7 @@ internal fun TypographyBodyTab(
             selectedValue = ReadBook.book?.getImageStyle() ?: Book.imgStyleDefault,
             displayEntries = imgStyleEntries,
             entryValues = imgStyleValues,
+            imageVector = Icons.Default.Image,
             onValueChange = { style ->
                 onIntent(ReadBookIntent.MenuImageStyle(style))
             },
@@ -455,6 +498,7 @@ internal fun TypographyTitleTab(
                 stringResource(R.string.title_hide),
             ),
             entryValues = arrayOf("0", "1", "2"),
+            imageVector = Icons.Default.Title,
             onValueChange = {
                 titleMode = it.toInt()
                 onIntent(ReadBookIntent.UpdateConfig(ConfigUpdate.TitleMode(titleMode)))
@@ -476,9 +520,10 @@ internal fun TypographyTitleTab(
             },
         )
         TinyColorModeSettingItem(
-            title = stringResource(R.string.title_color),
+            title = stringResource(R.string.color),
             dayColor = if (config.titleColor != 0) config.titleColor else config.textColorDay,
             nightColor = if (config.titleColorNight != 0) config.titleColorNight else config.textColorNight,
+            imageVector = Icons.Default.Palette,
             onClickColor = { isNight ->
                 if (isNight) {
                     onOpenColorPicker(TypographyColorTarget.TitleNight)
@@ -488,10 +533,11 @@ internal fun TypographyTitleTab(
             },
         )
         TinySliderSettingItem(
-            title = stringResource(R.string.title_font_size),
+            title = stringResource(R.string.font_size),
             value = titleSize.toFloat(),
             valueRange = 8f..60f,
             steps = 51,
+            imageVector = Icons.Default.FormatSize,
             valueFormat = { "${it.toInt()}sp" },
             onValueChange = { value ->
                 titleSize = value.toInt()
@@ -511,6 +557,7 @@ internal fun TypographyTitleTab(
                 stringResource(R.string.split_title_by_regex),
             ),
             entryValues = arrayOf("0", "1", "2", "3"),
+            imageVector = Icons.Default.CallSplit,
             onValueChange = {
                 titleSegType = it.toInt()
                 onIntent(ReadBookIntent.UpdateConfig(ConfigUpdate.TitleSegType(titleSegType)))
@@ -522,6 +569,7 @@ internal fun TypographyTitleTab(
                 value = titleSegDistance.toFloat(),
                 valueRange = 1f..20f,
                 steps = 18,
+                imageVector = Icons.Default.SpaceBar,
                 onValueChange = { value ->
                     titleSegDistance = value.toInt()
                     onIntent(ReadBookIntent.UpdateConfig(ConfigUpdate.TitleSegDistance(titleSegDistance)))
@@ -532,6 +580,7 @@ internal fun TypographyTitleTab(
             TinyClickableSettingItem(
                 title = stringResource(R.string.rule_segment),
                 description = titleSegFlag.ifBlank { stringResource(R.string.split_title_mode) },
+                imageVector = Icons.Default.Code,
                 onClick = { showFlagDialog = true },
             )
         }
@@ -541,6 +590,7 @@ internal fun TypographyTitleTab(
             valueRange = 0f..2f,
             steps = 19,
             stepSize = 0.1f,
+            imageVector = Icons.Default.AspectRatio,
             valueFormat = { "%.1f".format(it) },
             onValueChange = { value ->
                 titleSegScaling = (value * 10).roundToInt() / 10f
@@ -554,6 +604,7 @@ internal fun TypographyTitleTab(
             title = stringResource(R.string.heading_spacing),
             value = titleLineSpacingExtra.toFloat(),
             valueRange = 0f..20f,
+            imageVector = Icons.Default.LineWeight,
             onValueChange = { value ->
                 titleLineSpacingExtra = value.toInt()
                 onIntent(ReadBookIntent.UpdateConfig(ConfigUpdate.TitleLineSpacingExtra(titleLineSpacingExtra)))
@@ -563,6 +614,7 @@ internal fun TypographyTitleTab(
             title = stringResource(R.string.subtitle_margin),
             value = titleLineSpacingSub.toFloat(),
             valueRange = -30f..30f,
+            imageVector = Icons.Default.Height,
             onValueChange = { value ->
                 titleLineSpacingSub = value.toInt()
                 onIntent(ReadBookIntent.UpdateConfig(ConfigUpdate.TitleLineSpacingSub(titleLineSpacingSub)))
@@ -641,6 +693,7 @@ internal fun TypographyHeaderTab(
             selectedValue = headerMode.toString(),
             displayEntries = headerModes.values.toTypedArray(),
             entryValues = headerModes.keys.map { it.toString() }.toTypedArray(),
+            imageVector = Icons.Default.ViewHeadline,
             onValueChange = { onHeaderModeChange(it.toInt()) },
         )
         TipPositionDropdown(
@@ -648,6 +701,7 @@ internal fun TypographyHeaderTab(
             value = headerLeft,
             tipNames = tipNames,
             tipValues = tipValues,
+            imageVector = Icons.Default.AlignHorizontalLeft,
             onValueChange = { onTipChange(CustomTipTarget.HEADER_LEFT, it) },
         )
         TipPositionDropdown(
@@ -655,6 +709,7 @@ internal fun TypographyHeaderTab(
             value = headerMiddle,
             tipNames = tipNames,
             tipValues = tipValues,
+            imageVector = Icons.Default.AlignHorizontalCenter,
             onValueChange = { onTipChange(CustomTipTarget.HEADER_MIDDLE, it) },
         )
         TipPositionDropdown(
@@ -662,6 +717,7 @@ internal fun TypographyHeaderTab(
             value = headerRight,
             tipNames = tipNames,
             tipValues = tipValues,
+            imageVector = Icons.Default.AlignHorizontalRight,
             onValueChange = { onTipChange(CustomTipTarget.HEADER_RIGHT, it) },
         )
 
@@ -670,6 +726,7 @@ internal fun TypographyHeaderTab(
         TinySwitchSettingItem(
             title = stringResource(R.string.showLine),
             checked = showHeaderLine,
+            imageVector = Icons.Default.Minimize,
             onCheckedChange = { onShowHeaderLineChange(it) },
         )
         TinyColorSettingItem(
@@ -679,6 +736,7 @@ internal fun TypographyHeaderTab(
                 0 -> ReadBookConfig.textColor
                 else -> config.tipDividerColor
             },
+            imageVector = Icons.Default.Palette,
             onClick = { onOpenColorPicker(TypographyColorTarget.Divider) },
         )
 
@@ -690,18 +748,20 @@ internal fun TypographyHeaderTab(
             onClick = onOpenHeaderFontSelect,
         )
         TinySliderSettingItem(
-            title = stringResource(R.string.title_font_size),
+            title = stringResource(R.string.font_size),
             value = config.headerFontSize.toFloat(),
             valueRange = 0f..100f,
+            imageVector = Icons.Default.FormatSize,
             onValueChange = { value ->
                 onIntent(ReadBookIntent.UpdateConfig(ConfigUpdate.HeaderFontSize(value.toInt())))
                 onIntent(ReadBookIntent.SaveReadStyleConfig)
             },
         )
         TinyColorModeSettingItem(
-            title = stringResource(R.string.title_color),
+            title = stringResource(R.string.color),
             dayColor = if (config.tipHeaderColor != 0) config.tipHeaderColor else config.textColorDay,
             nightColor = if (config.tipHeaderColorNight != 0) config.tipHeaderColorNight else config.textColorNight,
+            imageVector = Icons.Default.FormatColorText,
             onClickColor = { isNight ->
                 if (isNight) {
                     onOpenColorPicker(TypographyColorTarget.HeaderNight)
@@ -749,6 +809,7 @@ internal fun TypographyFooterTab(
             selectedValue = footerMode.toString(),
             displayEntries = footerModes.values.toTypedArray(),
             entryValues = footerModes.keys.map { it.toString() }.toTypedArray(),
+            imageVector = Icons.Default.ViewAgenda,
             onValueChange = { onFooterModeChange(it.toInt()) },
         )
         TipPositionDropdown(
@@ -756,6 +817,7 @@ internal fun TypographyFooterTab(
             value = footerLeft,
             tipNames = tipNames,
             tipValues = tipValues,
+            imageVector = Icons.Default.AlignHorizontalLeft,
             onValueChange = { onTipChange(CustomTipTarget.FOOTER_LEFT, it) },
         )
         TipPositionDropdown(
@@ -763,6 +825,7 @@ internal fun TypographyFooterTab(
             value = footerMiddle,
             tipNames = tipNames,
             tipValues = tipValues,
+            imageVector = Icons.Default.AlignHorizontalCenter,
             onValueChange = { onTipChange(CustomTipTarget.FOOTER_MIDDLE, it) },
         )
         TipPositionDropdown(
@@ -770,6 +833,7 @@ internal fun TypographyFooterTab(
             value = footerRight,
             tipNames = tipNames,
             tipValues = tipValues,
+            imageVector = Icons.Default.AlignHorizontalRight,
             onValueChange = { onTipChange(CustomTipTarget.FOOTER_RIGHT, it) },
         )
 
@@ -778,6 +842,7 @@ internal fun TypographyFooterTab(
         TinySwitchSettingItem(
             title = stringResource(R.string.showLine),
             checked = showFooterLine,
+            imageVector = Icons.Default.Minimize,
             onCheckedChange = { onShowFooterLineChange(it) },
         )
 
@@ -786,6 +851,7 @@ internal fun TypographyFooterTab(
         TinySwitchSettingItem(
             title = stringResource(R.string.apply_header_style),
             checked = config.applyHeaderStyle,
+            imageVector = Icons.Default.CopyAll,
             onCheckedChange = {
                 onIntent(ReadBookIntent.UpdateConfig(ConfigUpdate.ApplyHeaderStyle(it)))
             },
@@ -797,18 +863,20 @@ internal fun TypographyFooterTab(
                 onClick = onOpenFooterFontSelect,
             )
             TinySliderSettingItem(
-                title = stringResource(R.string.title_font_size),
+                title = stringResource(R.string.font_size),
                 value = config.footerFontSize.toFloat(),
                 valueRange = 0f..100f,
+                imageVector = Icons.Default.FormatSize,
                 onValueChange = { value ->
                     onIntent(ReadBookIntent.UpdateConfig(ConfigUpdate.FooterFontSize(value.toInt())))
                     onIntent(ReadBookIntent.SaveReadStyleConfig)
                 },
             )
             TinyColorModeSettingItem(
-                title = stringResource(R.string.title_color),
+                title = stringResource(R.string.color),
                 dayColor = if (config.tipFooterColor != 0) config.tipFooterColor else config.textColorDay,
                 nightColor = if (config.tipFooterColorNight != 0) config.tipFooterColorNight else config.textColorNight,
+                imageVector = Icons.Default.FormatColorText,
                 onClickColor = { isNight ->
                     if (isNight) {
                         onOpenColorPicker(TypographyColorTarget.FooterNight)
@@ -885,6 +953,7 @@ internal fun TypographyMarginTab(
             title = stringResource(R.string.title_margin_top),
             value = titleTopSpacing.toFloat(),
             valueRange = 0f..200f,
+            imageVector = Icons.Default.VerticalAlignTop,
             onValueChange = { value ->
                 titleTopSpacing = value.toInt()
                 onIntent(ReadBookIntent.UpdateConfig(ConfigUpdate.TitleTopSpacing(titleTopSpacing)))
@@ -894,6 +963,7 @@ internal fun TypographyMarginTab(
             title = stringResource(R.string.title_margin_bottom),
             value = titleBottomSpacing.toFloat(),
             valueRange = 0f..200f,
+            imageVector = Icons.Default.VerticalAlignBottom,
             onValueChange = { value ->
                 titleBottomSpacing = value.toInt()
                 onIntent(ReadBookIntent.UpdateConfig(ConfigUpdate.TitleBottomSpacing(titleBottomSpacing)))

--- a/app/src/main/res/layout/dialog_read_info.xml
+++ b/app/src/main/res/layout/dialog_read_info.xml
@@ -84,7 +84,7 @@
             app:max="30"
             app:min="8"
             app:orientation="horizontal"
-            app:title="@string/title_font_size" />
+            app:title="@string/font_size" />
 
     </LinearLayout>
 
@@ -99,14 +99,14 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             style="@style/Widget.Material3Expressive.Button.OutlinedButton"
-            android:text="@string/title_color" />
+            android:text="@string/color" />
 
         <io.legado.app.ui.widget.AccentColorButton
             android:id="@+id/btn_footer_color"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             style="@style/Widget.Material3Expressive.Button.OutlinedButton"
-            android:text="@string/title_color" />
+            android:text="@string/color" />
 
         <io.legado.app.ui.widget.AccentColorButton
             android:id="@+id/btn_divider_color"

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1034,8 +1034,8 @@
     <string name="show_unread">显示未读标志</string>
     <string name="use_default_cover">总是使用默认封面</string>
     <string name="use_default_cover_s">总是显示默认封面（不显示网络封面）</string>
-    <string name="title_font_size">字号</string>
-    <string name="title_color">标题颜色</string>
+    <string name="font_size">字号</string>
+    <string name="color">颜色</string>
     <string name="reset_to_body_color">重置为正文颜色</string>
     <string name="title_margin_top">上边距</string>
     <string name="title_margin_bottom">下边距</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -890,7 +890,7 @@
     <string name="show_unread">顯示未讀標誌</string>
     <string name="use_default_cover">總是使用默認封面</string>
     <string name="use_default_cover_s">總是使用默認封面,唔顯示網路封面</string>
-    <string name="title_font_size">字號</string>
+    <string name="font_size">字號</string>
     <string name="title_margin_top">上邊距</string>
     <string name="title_margin_bottom">下邊距</string>
     <string name="show">顯示</string>
@@ -2251,7 +2251,7 @@
     <string name="title_bar_icons">標題欄圖標</string>
     <string name="title_bar_layout">標題欄佈局</string>
     <string name="title_bar_mode">選單中的標題模式</string>
-    <string name="title_color">標題顏色</string>
+    <string name="color">顏色</string>
     <string name="reset_to_body_color">重置為正文顏色</string>
     <string name="toc_disabled_format">%1$s 目錄已禁用</string>
     <string name="toc_rule_update_failed">章節規則更新失敗：%1$s</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -895,7 +895,7 @@
     <string name="show_unread">顯示未讀標誌</string>
     <string name="use_default_cover">總是使用預設封面</string>
     <string name="use_default_cover_s">總是顯示預設封面，不顯示網路封面</string>
-    <string name="title_font_size">字號</string>
+    <string name="font_size">字號</string>
     <string name="title_margin_top">上邊距</string>
     <string name="title_margin_bottom">下邊距</string>
     <string name="show">顯示</string>
@@ -1556,7 +1556,7 @@
     <string name="image_style_full">全螢幕</string>
     <string name="image_style_text">文字吸附</string>
     <string name="image_style_single">單頁</string>
-    <string name="title_color">標題顏色</string>
+    <string name="color">顏色</string>
     <string name="reset_to_body_color">重置為正文顏色</string>
     <string name="export_file_name_template_hint">{name} - {author}</string>
     <string name="export_file_name_template_help">可用變數：{name} 書名、{author} 作者、{group} 分組、{source} 來源、{remark} 備註。

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1070,8 +1070,8 @@
     <string name="toc_src">Chapters source code</string>
     <string name="content_src">Content source code</string>
     <string name="list_src">List source code</string>
-    <string name="title_font_size">Font Size</string>
-    <string name="title_color">Color</string>
+    <string name="font_size">Font Size</string>
+    <string name="color">Color</string>
     <string name="reset_to_body_color">Reset to body text color</string>
     <string name="title_margin_top">Margin Top</string>
     <string name="title_margin_bottom">Margin Bottom</string>


### PR DESCRIPTION
- 移除阅读设置页无用阴影配置入口，删除闲置简繁转换相关代码；
- 简化字体、颜色配置 key，移除多余title_前缀，全局同步所有引用；
- 为排版设置项补充 Material Icons。