### PR TITLE
fix: 书架布局模式切换不生效及列表封面未垂直居中

### DIFF
--- a/app/src/main/java/io/legado/app/ui/main/bookshelf/BookItem.kt
+++ b/app/src/main/java/io/legado/app/ui/main/bookshelf/BookItem.kt
@@ -221,7 +221,7 @@ fun BookshelfItem(
                 ) {
                     Box(
                         modifier = Modifier
-                            .align(Alignment.Top)
+                            .align(Alignment.CenterVertically)
                             .width(coverWidth.dp)
                     ) {
                         Box(

--- a/app/src/main/java/io/legado/app/ui/main/bookshelf/BookshelfScreen.kt
+++ b/app/src/main/java/io/legado/app/ui/main/bookshelf/BookshelfScreen.kt
@@ -407,23 +407,20 @@ fun BookshelfScreen(
 
     val configuration = LocalConfiguration.current
     val isLandscape = configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
-    val bookshelfFolderLayoutMode by remember(isLandscape) {
-        derivedStateOf {
-            if (isLandscape) uiState.settings.bookshelfFolderLayoutModeLandscape
-            else uiState.settings.bookshelfFolderLayoutModePortrait
-        }
+    val bookshelfFolderLayoutMode = if (isLandscape) {
+        uiState.settings.bookshelfFolderLayoutModeLandscape
+    } else {
+        uiState.settings.bookshelfFolderLayoutModePortrait
     }
-    val bookshelfFolderLayoutGrid by remember(isLandscape) {
-        derivedStateOf {
-            if (isLandscape) uiState.settings.bookshelfFolderLayoutGridLandscape
-            else uiState.settings.bookshelfFolderLayoutGridPortrait
-        }
+    val bookshelfFolderLayoutGrid = if (isLandscape) {
+        uiState.settings.bookshelfFolderLayoutGridLandscape
+    } else {
+        uiState.settings.bookshelfFolderLayoutGridPortrait
     }
-    val bookshelfFolderLayoutList by remember(isLandscape) {
-        derivedStateOf {
-            if (isLandscape) uiState.settings.bookshelfFolderLayoutListLandscape
-            else uiState.settings.bookshelfFolderLayoutListPortrait
-        }
+    val bookshelfFolderLayoutList = if (isLandscape) {
+        uiState.settings.bookshelfFolderLayoutListLandscape
+    } else {
+        uiState.settings.bookshelfFolderLayoutListPortrait
     }
     val currentMenuGroupId by remember {
         derivedStateOf { if (uiState.isSearch) uiState.selectedGroupId else currentTabGroupId }
@@ -1372,30 +1369,23 @@ fun BookshelfPage(
 
     val configuration = LocalConfiguration.current
     val isLandscape = configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
-    val bookshelfLayoutMode by remember(isLandscape) {
-        derivedStateOf {
-            if (isLandscape) uiState.settings.bookshelfLayoutModeLandscape
-            else uiState.settings.bookshelfLayoutModePortrait
-        }
+    val bookshelfLayoutMode = if (isLandscape) {
+        uiState.settings.bookshelfLayoutModeLandscape
+    } else {
+        uiState.settings.bookshelfLayoutModePortrait
     }
-    val bookshelfLayoutGrid by remember(isLandscape) {
-        derivedStateOf {
-            if (isLandscape) uiState.settings.bookshelfLayoutGridLandscape
-            else uiState.settings.bookshelfLayoutGridPortrait
-        }
+    val bookshelfLayoutGrid = if (isLandscape) {
+        uiState.settings.bookshelfLayoutGridLandscape
+    } else {
+        uiState.settings.bookshelfLayoutGridPortrait
     }
-    val bookshelfLayoutList by remember(isLandscape) {
-        derivedStateOf {
-            if (isLandscape) uiState.settings.bookshelfLayoutListLandscape
-            else uiState.settings.bookshelfLayoutListPortrait
-        }
+    val bookshelfLayoutList = if (isLandscape) {
+        uiState.settings.bookshelfLayoutListLandscape
+    } else {
+        uiState.settings.bookshelfLayoutListPortrait
     }
-    val columns by remember {
-        derivedStateOf {
-            if (bookshelfLayoutMode == 0) bookshelfLayoutList else bookshelfLayoutGrid
-        }
-    }
-    val isGridMode by remember { derivedStateOf { bookshelfLayoutMode != 0 } }
+    val columns = if (bookshelfLayoutMode == 0) bookshelfLayoutList else bookshelfLayoutGrid
+    val isGridMode = bookshelfLayoutMode != 0
     val bookItemGridStyle = uiState.settings.bookshelfGridLayout
     val bookItemIsCompact = uiState.settings.bookshelfLayoutCompact
     val bookItemTitleSmallFont = uiState.settings.bookshelfTitleSmallFont


### PR DESCRIPTION
布局模式（列表/网格）在设置中修改后不会立即生效，必须切换到其他
分组再切回来才会应用。

原因是 BookshelfScreen 中 `remember(isLandscape) { derivedStateOf { ... } }` 在首次组合时捕获了 uiState 参数，而 `uiState.settings.xxx` 是普通
data class 字段读取，不是快照状态。derivedStateOf 只在其读取的快照
状态变化时重算，因此设置更新后该值一直保持旧值；切换分组会重建
pager 页面并捕获新的 uiState，才使改动看似生效。

这些值都是 Int，直接在重组时读取即可，无需 derivedStateOf 缓存。
同样问题存在于分组文件夹视图的 bookshelfFolderLayout* 三个变量。

另外 BookshelfItem 列表模式下，外层 Row 已设置 CenterVertically， 但封面 Box 用 `.align(Alignment.Top)` 覆盖成了顶对齐，导致封面在
高度上未居中。