### PR TITLE
refactor(read): 简化标题字体大小的计算逻辑

### DIFF
--- a/app/src/main/java/io/legado/app/help/config/ReadBookConfig.kt
+++ b/app/src/main/java/io/legado/app/help/config/ReadBookConfig.kt
@@ -568,7 +568,7 @@ object ReadBookConfig {
         val lineSpacingExtra: Int = 12,//行间距
         val paragraphSpacing: Int = 2,//段距
         val titleMode: Int = 0,//标题位置 0:居左 1:居中 2:隐藏
-        val titleSize: Int = 0,
+        val titleSize: Int = 20,
         val titleTopSpacing: Int = 0,
         val titleBottomSpacing: Int = 0,
         val titleColor: Int = 0,

--- a/app/src/main/java/io/legado/app/ui/book/read/page/provider/ChapterProvider.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/page/provider/ChapterProvider.kt
@@ -460,7 +460,7 @@ object ChapterProvider {
         tPaint.typeface = titleFontTypeface
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P && ReadBookConfig.titleBold in 100..900)
             tPaint.setFontVariationSettings("'wght' ${ReadBookConfig.titleBold}")
-        tPaint.textSize = with(ReadBookConfig) { textSize + titleSize }.toFloat().spToPx()
+        tPaint.textSize = ReadBookConfig.titleSize.toFloat().spToPx()
         tPaint.isAntiAlias = true
         if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.Q && ReadConfig.optimizeRender) {
             tPaint.isLinearText = true

--- a/app/src/main/java/io/legado/app/ui/book/read/sheet/TypographyTabs.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/sheet/TypographyTabs.kt
@@ -436,14 +436,8 @@ internal fun TypographyTitleTab(
     var titleLineSpacingExtra by remember(config.titleLineSpacingExtra) { mutableIntStateOf(config.titleLineSpacingExtra) }
     var titleLineSpacingSub by remember(config.titleLineSpacingSub) { mutableIntStateOf(config.titleLineSpacingSub) }
 
-    // Title font size: <8 means relative offset (textSize + titleSize), >=8 means absolute
     var titleSize by remember(config.titleSize) {
-        val initial = if (config.titleSize < 8) {
-            (config.textSize + config.titleSize).coerceIn(8, 60)
-        } else {
-            config.titleSize
-        }
-        mutableIntStateOf(initial)
+        mutableIntStateOf(config.titleSize)
     }
 
     var showFlagDialog by remember { mutableStateOf(false) }


### PR DESCRIPTION
移除标题字号相对正文的偏移计算，改为直接使用配置的绝对字号值