### PR TITLE
fix: 书签跳转位置有误

### DIFF
--- a/app/src/main/java/io/legado/app/ui/book/read/ReadBookmarkDelegate.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/ReadBookmarkDelegate.kt
@@ -37,7 +37,7 @@ class ReadBookmarkDelegate(
                 bookAuthor = book.author,
                 chapterIndex = chapter.chapter.index,
                 chapterName = chapter.title,
-                chapterPos = ReadBook.durPageIndex,
+                chapterPos = ReadBook.durChapterPos,
                 bookText = page.text,
                 content = "",
             )

--- a/app/src/test/java/io/legado/app/ui/book/read/ReadBookDomainSplitBoundaryTest.kt
+++ b/app/src/test/java/io/legado/app/ui/book/read/ReadBookDomainSplitBoundaryTest.kt
@@ -46,6 +46,16 @@ class ReadBookDomainSplitBoundaryTest {
     }
 
     @Test
+    fun `菜单书签保存章节内字符位置而不是页码`() {
+        val source = mainSourceFile("io/legado/app/ui/book/read/ReadBookmarkDelegate.kt").readText()
+        assertTrue(
+            "书签 chapterPos 必须保存章节内字符位置，否则跳转时页码会被误当成字符偏移",
+            "chapterPos = ReadBook.durChapterPos" in source &&
+                "chapterPos = ReadBook.durPageIndex" !in source,
+        )
+    }
+
+    @Test
     fun `ReadBookViewModel 不再持有各域的实现`() {
         val source = mainSourceFile("io/legado/app/ui/book/read/ReadBookViewModel.kt").readText()
         DOMAINS.forEach { domain ->


### PR DESCRIPTION
Closes #1960

  ## 问题说明

  通过阅读菜单添加书签后，从书签列表跳转到该书签时，阅读器会打开正确的章节，但通常定位到章节开头，而不是添加书签时所在的位置。

  ## 问题原因

  `Bookmark.chapterPos` 表示章节内的字符位置，但创建菜单书签时错误地保存了当前页码：

  ```kotlin
  chapterPos = ReadBook.durPageIndex

  书签跳转时，chapterPos 会作为章节内字符偏移量传递给阅读器。页码通常是一个较小的数值，因此会被定位到章节前几个字符所在的第一页。

  ## 修改内容

  将菜单书签保存的位置改为当前章节内字符位置：

  chapterPos = ReadBook.durChapterPos

  本次修改仅修正位置字段的赋值，不调整书签数据结构、数据库或现有跳转流程。

  同时增加回归测试，确保菜单书签保存的是章节内字符位置，而不是页码。

  ## 验证结果

  - :app:compileAppDebugKotlin 编译通过。
  - git diff --check 检查通过。
  - 目标单元测试目前被仓库中既有的 OtherConfigViewModelTest 编译错误阻断，与本次修改无关。

  ## 兼容性说明

  此前已经使用错误页码保存的书签无法可靠还原原始字符位置，需要删除后重新添加。

  新创建的书签会正确跳转到添加书签时所在的阅读位置。
