### PR TITLE
fix:修复seek无法刷新的问题

### DIFF
--- a/app/src/main/java/io/legado/app/ui/book/read/ReadBookController.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/ReadBookController.kt
@@ -194,7 +194,7 @@ class ReadBookController(
     private val prevPageDebounce by lazy { Debounce { keyPage(PageDirection.PREV) } }
 
     private val upSeekBarThrottle = throttle(200) {
-        onUnhandledEffect(ReadBookEffect.UpSeekBar)
+        viewModel.refreshSeekState()
     }
 
     fun onRefsReady(newRefs: ReadBookViewRefs) {
@@ -1050,6 +1050,7 @@ class ReadBookController(
                     consumePendingSearchResultMark()
                 }
                 if (effect.relativePosition == 0) onUnhandledEffect(ReadBookEffect.UpSeekBar)
+                if (effect.relativePosition == 0) viewModel.refreshSeekState()
             }
 
             is ReadBookEffect.UpPageAnim -> refs?.readView?.upPageAnim(effect.upRecorder)

--- a/app/src/main/java/io/legado/app/ui/book/read/ReadBookViewModel.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/ReadBookViewModel.kt
@@ -2321,6 +2321,13 @@ class ReadBookViewModel(
         }
     }
 
+    fun refreshSeekState() {
+        _uiState.update { it.copy(
+            seekProgress = calculateSeekProgress(),
+            seekMax = calculateSeekMax(),
+        ) }
+    }
+
     private fun openChapterUrl() {
         if (ReadBook.isLocalBook) return
         viewModelScope.launch {


### PR DESCRIPTION
bug：进度条设置为调整本章页数，打开新书后seekMax被固定为0，只有点击下一页才会刷新seekMax
加入刷新机制