### PR TITLE
fix: 底栏填充样式着色层半透明,修复模糊被完全遮住

### DIFF
--- a/app/src/main/java/io/legado/app/ui/widget/components/reader/ReaderMenuEffects.kt
+++ b/app/src/main/java/io/legado/app/ui/widget/components/reader/ReaderMenuEffects.kt
@@ -26,7 +26,7 @@ fun Modifier.readerMenuHazeEffect(
     val style = HazeLegado.custom(
         containerColor = resolvedColor.copy(alpha = surfaceAlpha.coerceIn(0, 100) / 100f),
         blurRadius = blurRadius,
-        blurAlpha = surfaceAlpha,
+        blurAlpha = menuTintAlpha(surfaceAlpha),
     )
 
     return hazeEffect(state = state, style = style) {
@@ -40,3 +40,15 @@ fun Modifier.readerMenuHazeEffect(
         }
     }
 }
+
+/**
+ * 着色层(tint)的不透明度上限。
+ *
+ * HazeStyle 的 tint 绘制在模糊内容之上，其 alpha 由「菜单不透明度」readMenuBlurAlpha 决定
+ * （默认 100 → 1.0 完全不透明）。若填充样式（progressive = null）直接使用该值，tint 会
+ * 完全遮住底层模糊，表现为「填充无模糊、渐变才有模糊」。封顶到半透明可保证模糊始终可见。
+ */
+internal const val MAX_MENU_TINT_ALPHA = 60
+
+internal fun menuTintAlpha(blurAlpha: Int): Int =
+    blurAlpha.coerceIn(0, MAX_MENU_TINT_ALPHA)

--- a/app/src/test/java/io/legado/app/ui/widget/components/reader/ReaderMenuTintAlphaTest.kt
+++ b/app/src/test/java/io/legado/app/ui/widget/components/reader/ReaderMenuTintAlphaTest.kt
@@ -1,0 +1,36 @@
+package io.legado.app.ui.widget.components.reader
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * 底栏菜单着色层(tint)不透明度封顶逻辑测试。
+ *
+ * 背景：HazeStyle 的 tint 绘制在模糊内容之上，「菜单不透明度」readMenuBlurAlpha 默认 100
+ * （= 1.0 完全不透明）。填充样式下若直接用该值，tint 会完全遮住模糊，表现为 issue #2044
+ * 「底栏填充样式无模糊效果，只有渐变才生效」。封顶到半透明可保证模糊始终可见。
+ */
+class ReaderMenuTintAlphaTest {
+
+    @Test
+    fun `clamps tint alpha at max to keep blur visible`() {
+        // 菜单不透明度拉满(100)时，着色层仍半透明，模糊可见
+        assertEquals(MAX_MENU_TINT_ALPHA, menuTintAlpha(100))
+        assertEquals(MAX_MENU_TINT_ALPHA, menuTintAlpha(80))
+        assertEquals(MAX_MENU_TINT_ALPHA, menuTintAlpha(Int.MAX_VALUE))
+    }
+
+    @Test
+    fun `clamps tint alpha at zero`() {
+        assertEquals(0, menuTintAlpha(0))
+        assertEquals(0, menuTintAlpha(-5))
+        assertEquals(0, menuTintAlpha(Int.MIN_VALUE))
+    }
+
+    @Test
+    fun `keeps in-range tint alpha unchanged`() {
+        assertEquals(30, menuTintAlpha(30))
+        assertEquals(50, menuTintAlpha(50))
+        assertEquals(60, menuTintAlpha(60))
+    }
+}


### PR DESCRIPTION
## 修复内容

修复底栏「着色样式 = 填充」时无模糊效果的问题（issue #2044）。

### 根因

底栏模糊走 `readerMenuHazeEffect`（`ReaderMenuEffects.kt`），着色样式「填充/渐变」的唯一区别是 `progressive` 参数；而 `HazeLegado.custom` 中 tint（着色层）的 alpha 直接取「菜单不透明度」`readMenuBlurAlpha`（默认 100 → 1.0 完全不透明）：

- **填充**（`progressive = null`）：tint 均匀 alpha=1.0，完全遮住底层模糊 → 无模糊
- **渐变**（`progressive = verticalGradient`）：tint 顶部 alpha 被拉到 0，才碰巧露出模糊 → 有模糊

底栏 `readMenuBlurAlpha` 默认 100，而顶栏 `topBarBlurAlpha` 默认 73，所以只有底栏暴露此问题。

### 改动

`app/src/main/java/io/legado/app/ui/widget/components/reader/ReaderMenuEffects.kt`：

- 着色层不透明度封顶 `MAX_MENU_TINT_ALPHA = 60`，新增 `menuTintAlpha(blurAlpha)` 纯函数，保证 tint 永远半透明、模糊始终可见
- `readerMenuHazeEffect` 中 `blurAlpha` 改用 `menuTintAlpha(surfaceAlpha)`

只改底栏专用的 `readerMenuHazeEffect`，不触碰全局主题 Haze（`responsiveHazeEffect` 也走 `HazeLegado.custom`，不受影响）。

### 验证

- 新增 `ReaderMenuTintAlphaTest`（3 个用例）：上限封顶、下限钳制、范围内不变
- 本地 `testDebugUnitTest` 通过（3/3，0 失败）

Closes #2044
