### PR TITLE
fix: 目录更新后新增章节点击无法跳转

### DIFF
--- a/app/src/main/java/io/legado/app/model/ReadBook.kt
+++ b/app/src/main/java/io/legado/app/model/ReadBook.kt
@@ -983,7 +983,11 @@ object ReadBook : CoroutineScope by MainScope(), KoinComponent {
         upContent: Boolean = true,
         success: (() -> Unit)? = null
     ) {
-        if (index < chapterSize) {
+        // 实时读取章节数而不是依赖缓存 chapterSize：更新目录后 chapterSize 若未同步，
+        // 新增章节的 index 会超出旧值而被下方守卫静默吞掉，表现为「点击新章节无法跳转」。
+        val chapterCount = book?.bookUrl?.let { appDb.bookChapterDao.getChapterCount(it) }
+            ?: chapterSize
+        if (index < chapterCount) {
             clearTextChapter()
             if (upContent) renderCallBack?.upContent()
             durChapterIndex = index


### PR DESCRIPTION
## 修复内容

修复新版目录「更新目录」后，新增章节点击无法跳转的问题（issue #2043）。

### 根因

`ReadBook.openChapter` 用**缓存的 `chapterSize`** 作为跳转守卫：

```kotlin
if (index < chapterSize) {
    durChapterIndex = index
    loadContent(...)
}
// else: 静默 return，不跳转也不报错
```

「更新目录」后若 `chapterSize` 未同步为新值（`onChapterListUpdated` 外层有 `isSameNameAuthor` 判断、无 else 分支，状态未同步时会静默跳过），**新增章节的 index 会超出旧的 `chapterSize`，被守卫静默吞掉**，表现为「点击新章节无反应、还在原章节」。旧章节 index 在旧值范围内，所以能正常跳转——与 issue 描述完全一致。

### 改动

`ReadBook.openChapter` 守卫改为**实时读取章节数**，不再依赖可能过期的缓存：

```kotlin
val chapterCount = book?.bookUrl?.let { appDb.bookChapterDao.getChapterCount(it) }
    ?: chapterSize
if (index < chapterCount) { ... }
```

### 验证

- 真机（小米 14 Pro + Android 16）复现：手动删除某书最后 2 章制造「旧目录」→ 更新目录刷回 528 章 → 点击新增 2 章，**修复后能正常跳转**（修复前点不动）；旧章节对照正常
- 本地 `assembleAppDebug` 编译通过

Closes #2043
