### PR TITLE
feat: 恢复扫码导入书源入口

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,6 +22,7 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
+    <uses-permission android:name="android.permission.CAMERA" />
 
     <application
         android:name=".App"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,6 +23,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.CAMERA" />
+    <uses-feature android:name="android.hardware.camera" android:required="false" />
 
     <application
         android:name=".App"

--- a/app/src/main/java/io/legado/app/ui/book/source/manage/BookSourceScreen.kt
+++ b/app/src/main/java/io/legado/app/ui/book/source/manage/BookSourceScreen.kt
@@ -49,6 +49,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import io.legado.app.R
 import io.legado.app.service.BookSourceCheckService
+import io.legado.app.ui.qrcode.QrCodeResult
 import io.legado.app.ui.theme.LegadoTheme
 import io.legado.app.ui.theme.adaptiveContentPadding
 import io.legado.app.ui.widget.components.ActionItem
@@ -218,6 +219,10 @@ fun BookSourceScreen(
                     onIntent(BookSourceIntent.Import(reader.readText()))
                 }
             }
+        }
+    val qrCodeImport =
+        rememberLauncherForActivityResult(QrCodeResult()) { result ->
+            result?.let { onIntent(BookSourceIntent.Import(it)) }
         }
     val exportDocument =
         rememberLauncherForActivityResult(ActivityResultContracts.CreateDocument("application/json")) { uri ->
@@ -524,6 +529,9 @@ fun BookSourceScreen(
                     )
                 )
                 })
+            RoundDropdownMenuItem(
+                text = stringResource(R.string.import_by_qr_code),
+                onClick = { dismiss(); qrCodeImport.launch(null) })
             RoundDropdownMenuItem(
                 text = stringResource(R.string.import_on_line),
                 onClick = { dismiss(); showOnlineImport = true })


### PR DESCRIPTION
## 背景

书源管理页从 View 重构为 Compose（BookSourceScreen）时，扫码导入入口未迁移，导致
QrCodeActivity / QrCodeResult 成为无调用点的死代码（`import_by_qr_code` 等字符串资源也随之
成为死资源）。当前导入方式仅剩「本地导入」「在线导入」两项。

## 改动

- BookSourceScreen 导入菜单新增「二维码导入」项，用 QrCodeResult 拉起扫码，
  结果走 `BookSourceIntent.Import`，与在线导入共用同一处理链
- AndroidManifest 补齐 CAMERA 权限声明（zxing-lite 相机扫码所需）
- 复用既有 `import_by_qr_code` 字符串资源，无新增文案

## 验证

- 本地 `./gradlew :app:compileAppDebugKotlin` 编译通过（JDK 21）
- 本地 `./gradlew :app:testAppDebugUnitTest` 单元测试通过
- 本地 `./gradlew assembleAppDebug` 构建通过
- 真机测试通过：书源管理 → 二维码导入 → 相机权限弹窗正常 → 扫码识别 → 导入确认 → 书源进列表
