### PR TITLE
fix: web接口 saveReplaceRule/deleteReplaceRule 成功时响应仍为 isSuccess=false

### DIFF
--- a/app/src/main/java/io/legado/app/api/controller/ReplaceRuleController.kt
+++ b/app/src/main/java/io/legado/app/api/controller/ReplaceRuleController.kt
@@ -30,6 +30,7 @@ object ReplaceRuleController {
                 rule.order = appDb.replaceRuleDao.maxOrder + 1
             }
             appDb.replaceRuleDao.insert(rule)
+            returnData.setData(rule)
         }
         return returnData
     }
@@ -43,6 +44,7 @@ object ReplaceRuleController {
             returnData.setErrorMsg("格式不对")
         } else {
             appDb.replaceRuleDao.delete(rule)
+            returnData.setData(rule)
         }
         return returnData
     }


### PR DESCRIPTION
Closes #2030

通过 web 接口 `POST /saveReplaceRule` / `POST /deleteReplaceRule` 保存/删除替换规则时，规则实际已写入数据库（`GET /getReplaceRules` 能查到），但响应始终是：

```json
{"errorMsg":"未知错误,请联系开发者!","isSuccess":false}
```

## 根因

`ReplaceRuleController.saveRule` / `delete` 的成功路径直接 `return returnData`，没有调用 `setData()`。`ReturnData` 默认 `isSuccess = false`、`errorMsg = "未知错误,请联系开发者!"`，只有 `setData()` 会置 `isSuccess = true` 并清空 errorMsg，因此成功/失败无法区分。

## 改动

成功路径补上 `returnData.setData(rule)`，与 `BookSourceController.saveSource` 等成功路径保持一致：

- `saveRule`：`insert(rule)` 之后 `setData(rule)`
- `delete`：`delete(rule)` 之后 `setData(rule)`

## 验证

- `./gradlew.bat :app:compileAppDebugKotlin --no-daemon` → BUILD SUCCESSFUL
