### PR TITLE
fix(reader): 行高排除异常 leading，修复部分字体顶部行距过大

### DIFF
--- a/app/src/main/java/io/legado/app/feature/reader/platform/AndroidReaderTextShaper.kt
+++ b/app/src/main/java/io/legado/app/feature/reader/platform/AndroidReaderTextShaper.kt
@@ -11,6 +11,7 @@ import io.legado.app.feature.reader.core.layout.ReaderFontBounds
 import io.legado.app.feature.reader.core.layout.ReaderFontLineMetrics
 import io.legado.app.feature.reader.core.layout.clusterGlyphs
 import io.legado.app.feature.reader.core.model.ReaderTextStyle
+import io.legado.app.utils.validFontLeading
 import java.io.File
 import splitties.init.appCtx
 
@@ -36,8 +37,8 @@ object ReaderAndroidPaintFactory {
 
     fun createTextPaint(style: ReaderTextStyle): TextPaint = TextPaint(create(style))
 
-    /** The reader's line box uses descent - ascent + leading; baseline = line bottom - descent. */
-    fun baselineOffset(paint: Paint): Float = paint.fontMetrics.let { it.leading - it.ascent }
+    /** 行盒基线偏移：行高已排除异常 leading（见 PaintExtensions.validFontLeading）。 */
+    fun baselineOffset(paint: Paint): Float = paint.fontMetrics.let { paint.validFontLeading - it.ascent }
 
     fun loadTypeface(path: String, weight: Int, italic: Boolean, family: String = "sans-serif"): Typeface {
         val key = "$path|$weight|$italic|$family"
@@ -74,7 +75,9 @@ class AndroidReaderTextShaper(paint: TextPaint) : ReaderTextShaper {
     private val paint = TextPaint(paint).apply { letterSpacing = 0f }
     override val fontBounds = this.paint.fontMetrics.let { ReaderFontBounds(it.top, it.bottom, it.descent) }
     override val fontLineMetrics = this.paint.fontMetrics.let {
-        val height = it.descent - it.ascent + it.leading
+        // 行盒高度与 utils/PaintExtensions.textHeight 同规则：异常 leading 不计入
+        //（如方正新楷体声明 leading≈1em，原样计入会让行高翻倍、空隙全在字形上方）
+        val height = it.descent - it.ascent + this.paint.validFontLeading
         ReaderFontLineMetrics(
             heightPx = height,
             baselineOffsetPx = height - it.descent,

--- a/app/src/main/java/io/legado/app/utils/PaintExtensions.kt
+++ b/app/src/main/java/io/legado/app/utils/PaintExtensions.kt
@@ -1,10 +1,26 @@
 package io.legado.app.utils
 
+import android.graphics.Paint
 import android.os.Build
 import android.text.TextPaint
 
+/**
+ * 计入行盒的字体 leading。
+ *
+ * 正常情况下 leading 是字体建议的行间隙，应计入行高；但部分字体文件
+ * （如方正新楷体）把 leading 声明为异常大的值（约等于 1em），按原值
+ * 计算会导致行高翻倍且空隙全堆到字形上方。因此当 leading 超过字体
+ * 高度（descent-ascent）的 15% 时，视为字体文件异常，返回 0 不计入。
+ */
+val Paint.validFontLeading: Float
+    get() = fontMetrics.run {
+        val height = descent - ascent
+        if (leading > height * 0.15f) 0f else leading
+    }
+
+/** 文本行高：descent - ascent 加上 [validFontLeading]（异常 leading 已排除）。 */
 val TextPaint.textHeight: Float
-    get() = fontMetrics.run { descent - ascent + leading }
+    get() = fontMetrics.run { descent - ascent + validFontLeading }
 
 fun TextPaint.getTextWidthsCompat(text: String, widths: FloatArray) {
     getTextWidths(text, widths)


### PR DESCRIPTION
## 问题

部分字体文件（汉王电子墨水屏设备的定制字体、方正新楷体 FZXKT--GB4-0 等）把 `fontMetrics.leading` 声明为**异常大的值（约等于 1em）**。行盒按 `descent - ascent + leading` 计算时行高直接翻倍，且多出来的空隙全部堆在字形上方。

实测环境：汉王 Clear7 电子墨水屏设备，系统字体当前选择为方正新楷体。`textSize=24sp` 时该字体实际度量：

```
ascent = -44.18   descent = 7.80   leading = 51.98   (leading ≈ 1em)
```

修复前——行盒高 104px，实测行距 107px，一页只能排半章内容：

![修复前](https://raw.githubusercontent.com/Mupceet/legado-with-MD3/pr-evidence/leading-before.png)

修复后——行盒高 52px，实测行距 52px，同一本书同一设置下整章一页排完：

![修复后](https://raw.githubusercontent.com/Mupceet/legado-with-MD3/pr-evidence/leading-after.png)

（两张截图来自同一台设备、同一个应用、同一本书、同一套排版设置，唯一差异是本补丁。）

## 修复

引入 `Paint.validFontLeading`：**leading 超过字体高度（descent - ascent）的 15% 时视为字体文件异常，不计入行盒**；正常字体的行间隙完整保留。规则应用到全部三处行盒计算：

1. `utils/PaintExtensions.kt` 的 `TextPaint.textHeight`——`ReaderPaginationConfig` 行高、空行与段距计算；
2. `AndroidReaderTextShaper.fontLineMetrics`——正文/标题的实际行盒（**视觉行距的真正来源**，此前裸算 `descent - ascent + leading`，即使修了 textHeight 也不生效）；
3. `ReaderAndroidPaintFactory.baselineOffset`——行盒基线偏移。

## 验证

- 汉王 Clear7 真机（Android 14/bengal，方正新楷体系统字体）：同一本书、同一套设置，修复前行距 107px（整章 2 页），修复后 52px（整章 1 页），中英混排基线对齐正常，段落间距与页眉页脚不受影响。
- 该 15% 规则参考设计说明，正常字体不会有过大的 leading 值，正常字体（思源黑体/宋体等）行距无变化。

## 说明

- 正常字体（leading ≤ 高度 15%）渲染结果与本 PR 前完全一致，只影响异常字体的表现。
