### PR TITLE
fix(backup): 划线笔记表 book_marks 纳入备份与恢复（随书签忽略项统一控制）

### DIFF
--- a/app/src/main/java/io/legado/app/data/dao/BookMarkingDao.kt
+++ b/app/src/main/java/io/legado/app/data/dao/BookMarkingDao.kt
@@ -10,6 +10,18 @@ import kotlinx.coroutines.flow.Flow
 @Dao
 interface BookMarkingDao {
 
+    @get:Query(
+        """
+        select * from book_marks
+        order by bookName collate localized, bookAuthor collate localized, chapterIndex, createdAt
+    """
+    )
+    val all: List<BookMarking>
+
+    /** 恢复备份用：按主键整批写入（同 id 覆盖，重复导入幂等）。 */
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(vararg bookMarkings: BookMarking)
+
     /**
      * 按创建时的源（bookUrl）查：渲染只画当前源能对上正文的标记。
      * 与 bookmarks 不同，book_marks 认「书名+作者」跨源关联，列表见 [flowByBook]。

--- a/app/src/main/java/io/legado/app/help/storage/Backup.kt
+++ b/app/src/main/java/io/legado/app/help/storage/Backup.kt
@@ -67,6 +67,7 @@ object Backup {
         arrayOf(
             "bookshelf.json",
             "bookmark.json",
+            "bookMarking.json",
             "bookGroup.json",
             "bookSource.json",
             "rssSources.json",
@@ -149,8 +150,10 @@ object Backup {
             "bookshelf.json",
             backupPath,
         )
+        // 书签与划线/想法笔记（book_marks）视为一体，统一受既有 bookmark 忽略项控制
         if (BackupConfig.dbIsNotIgnored("bookmark", true)) {
             writeListToJson(appDb.bookmarkDao.all, "bookmark.json", backupPath)
+            writeListToJson(appDb.bookMarkingDao.all, "bookMarking.json", backupPath)
         }
         if (BackupConfig.dbIsNotIgnored("bookGroup", true)) {
             writeListToJson(appDb.bookGroupDao.all, "bookGroup.json", backupPath)

--- a/app/src/main/java/io/legado/app/help/storage/Restore.kt
+++ b/app/src/main/java/io/legado/app/help/storage/Restore.kt
@@ -16,6 +16,7 @@ import io.legado.app.data.entities.Book
 import io.legado.app.data.entities.BookGroup
 import io.legado.app.data.entities.BookSource
 import io.legado.app.data.entities.Bookmark
+import io.legado.app.data.entities.BookMarking
 import io.legado.app.data.entities.DictRule
 import io.legado.app.data.entities.HighlightRule
 import io.legado.app.data.entities.HighlightTagRule
@@ -148,10 +149,17 @@ object Restore : KoinComponent {
                 }
             }
         }
+        // 书签与划线/想法笔记（book_marks）视为一体，统一受既有 bookmark 忽略项控制
         if (BackupConfig.dbIsNotIgnored("bookmark")) {
             fileToListT<Bookmark>(path, "bookmark.json")?.let {
                 try {
                     appDb.bookmarkDao.insert(*it.toTypedArray())
+                } catch (_: SQLiteConstraintException) {
+                }
+            }
+            fileToListT<BookMarking>(path, "bookMarking.json")?.let {
+                try {
+                    appDb.bookMarkingDao.insert(*it.toTypedArray())
                 } catch (_: SQLiteConstraintException) {
                 }
             }


### PR DESCRIPTION
## 问题

笔记功能（`book_marks` 表 / `BookMarking`）自 a130dddc4 引入以来未接入备份体系：`Backup.kt` 导出清单与 `Restore.kt` 恢复流程均不含该表，本地备份与 WebDav 备份都不携带笔记——换机或恢复备份后会丢失全部划线与想法。

## 修复内容

- `BookMarkingDao`：补 `all`（导出用，按书名/作者/章/时间排序）与 `insert(vararg)`（恢复写入，主键 REPLACE 幂等，重复导入不翻倍）
- `Backup.kt`：`bookmark` 导出块内新增 `bookMarking.json`，zip 清单同步登记
- `Restore.kt`：`bookmark` 恢复块内新增 `bookMarking.json` 恢复（与其他表同构，文件缺失时自然跳过）

## 设计取舍

书签（bookmarks）与划线/想法笔记（book_marks）视为一体的阅读批注数据：**不新增独立忽略项**，`bookMarking.json` 完全随既有 `bookmark` 忽略项（备份与恢复两侧）统一控制——忽略清单不膨胀，老用户已勾选「忽略书签」的配置对新数据自动生效，`BackupConfig` 零改动。

## 兼容性

- 旧备份恢复：`bookMarking.json` 不存在时 `fileToListT` 返回 null 自动跳过
- 新备份在旧版本恢复：多余 zip 条目被旧版清单过滤，无影响
- WebDav 走全量 zip，自动携带
- Room 仅新增 DAO 查询/插入方法，无 schema 变化

## 验证

- `:app:compileAppDebugKotlin` BUILD SUCCESSFUL
- `:app:testAppDebugUnitTest`：4 个失败类（ReaderLongImageScroll / ReaderPageTransition / AnalyzeRuleFastPath / ReadBookDomainSplitBoundary）均为 main 分支既有失败，与本改动无关，零新增
- 手动路径建议：备份 → 检查 zip 内含 `bookMarking.json` → 清数据恢复 → 划线/想法还原，重复恢复不重复