### PR TITLE
fix(source-management): 完善删除确认与书源操作提示

### DIFF
--- a/app/src/main/java/io/legado/app/ui/book/source/manage/BookSourceScreen.kt
+++ b/app/src/main/java/io/legado/app/ui/book/source/manage/BookSourceScreen.kt
@@ -172,7 +172,7 @@ fun BookSourceScreen(
     var showOnlineImport by remember { mutableStateOf(false) }
     var checkSourceIds by remember { mutableStateOf<Set<String>?>(null) }
     var checkSheet by remember { mutableStateOf<CheckSheet?>(null) }
-    var checkOptionsDraft by remember { mutableStateOf(state.checkOptions) }
+    var checkOptionsDraft by remember(state.checkOptions) { mutableStateOf(state.checkOptions) }
     var pendingExportIds by remember { mutableStateOf<Set<String>>(emptySet()) }
     var showExportSheet by remember { mutableStateOf(false) }
     var showImportOptions by remember { mutableStateOf(false) }
@@ -414,6 +414,7 @@ fun BookSourceScreen(
         deleteIds,
         { deleteIds = null },
         stringResource(R.string.delete),
+        text = stringResource(R.string.sure_del),
         confirmText = stringResource(R.string.ok),
         onConfirm = { ids -> onIntent(BookSourceIntent.Delete(ids)); deleteIds = null },
         dismissText = stringResource(R.string.cancel),
@@ -513,7 +514,10 @@ fun BookSourceScreen(
                 showExportSheet = true
             },
         ),
-        onDeleteSelected = { deleteIds = @Suppress("UNCHECKED_CAST") (it as Set<String>) },
+        onDeleteSelected = {
+            @Suppress("UNCHECKED_CAST")
+            onIntent(BookSourceIntent.Delete(it as Set<String>))
+        },
         dropDownMenuContent = { dismiss ->
             RoundDropdownMenuItem(
                 text = stringResource(R.string.group_manage),
@@ -766,7 +770,8 @@ private fun CheckBookSourceSheet(
     onOpenSettings: () -> Unit,
     onConfirm: (Set<String>, String, BookSourceCheckOptionsUi) -> Unit,
 ) {
-    var keyword by remember(sourceIds) { mutableStateOf("我的") }
+    val defaultKeyword = stringResource(R.string.book_source_check_default_keyword)
+    var keyword by remember(sourceIds, defaultKeyword) { mutableStateOf(defaultKeyword) }
     AppModalBottomSheet(
         data = sourceIds,
         onDismissRequest = onDismissRequest,

--- a/app/src/main/java/io/legado/app/ui/book/source/manage/BookSourceViewModel.kt
+++ b/app/src/main/java/io/legado/app/ui/book/source/manage/BookSourceViewModel.kt
@@ -476,7 +476,10 @@ class BookSourceViewModel(
                 )
             }.onSuccess { importState.value = it }
                 .onFailure {
-                    importState.value = BaseImportUiState.Error(it.localizedMessage ?: "导入失败")
+                    importState.value = BaseImportUiState.Error(
+                        it.localizedMessage
+                            ?: application.getString(io.legado.app.R.string.book_source_import_failed)
+                    )
                 }
         }
     }
@@ -503,9 +506,11 @@ class BookSourceViewModel(
                 } else listOf(GSON.fromJsonObject<BookSource>(text).getOrThrow())
             }
 
-            else -> error("格式不正确")
+            else -> error(application.getString(io.legado.app.R.string.invalid_format))
         }
-        require(sources.all { it.bookSourceUrl.isNotBlank() }) { "不是书源" }
+        require(sources.all { it.bookSourceUrl.isNotBlank() }) {
+            application.getString(io.legado.app.R.string.book_source_invalid_source)
+        }
         return sources
     }
 
@@ -569,7 +574,11 @@ class BookSourceViewModel(
             ContentProcessor.upReplaceRules()
             importState.value = BaseImportUiState.Idle
             _effects.tryEmit(BookSourceEffect.ImportFinished)
-            _effects.tryEmit(BookSourceEffect.ShowSnackbar("导入完成"))
+            _effects.tryEmit(
+                BookSourceEffect.ShowSnackbar(
+                    application.getString(io.legado.app.R.string.book_source_import_success)
+                )
+            )
         }
     }
 
@@ -578,9 +587,23 @@ class BookSourceViewModel(
             val selected = repository.getAll().filter { ids.isEmpty() || it.bookSourceUrl in ids }
             application.contentResolver.openOutputStream(uri)?.bufferedWriter()
                 ?.use { it.write(GSON.toJson(selected)) }
-                ?: error("无法打开导出文件")
-        }.onSuccess { _effects.tryEmit(BookSourceEffect.ShowSnackbar("导出成功")) }
-            .onFailure { _effects.tryEmit(BookSourceEffect.ShowSnackbar("导出失败: ${it.localizedMessage}")) }
+                ?: error(application.getString(io.legado.app.R.string.book_source_export_open_failed))
+        }.onSuccess {
+            _effects.tryEmit(
+                BookSourceEffect.ShowSnackbar(
+                    application.getString(io.legado.app.R.string.export_success)
+                )
+            )
+        }.onFailure {
+            _effects.tryEmit(
+                BookSourceEffect.ShowSnackbar(
+                    application.getString(
+                        io.legado.app.R.string.book_source_export_failed,
+                        it.localizedMessage.orEmpty(),
+                    )
+                )
+            )
+        }
     }
 
     private fun uploadSources(ids: Set<String>) = launch {
@@ -594,13 +617,20 @@ class BookSourceViewModel(
         }.onSuccess { url ->
             _effects.tryEmit(
                 BookSourceEffect.ShowSnackbar(
-                    message = "上传成功: $url",
-                    actionLabel = "复制链接",
+                    message = application.getString(io.legado.app.R.string.book_source_upload_success, url),
+                    actionLabel = application.getString(io.legado.app.R.string.copy_url),
                     url = url,
                 )
             )
         }.onFailure {
-            _effects.tryEmit(BookSourceEffect.ShowSnackbar("上传失败: ${it.localizedMessage}"))
+            _effects.tryEmit(
+                BookSourceEffect.ShowSnackbar(
+                    application.getString(
+                        io.legado.app.R.string.book_source_upload_failed,
+                        it.localizedMessage.orEmpty(),
+                    )
+                )
+            )
         }
     }
 

--- a/app/src/main/java/io/legado/app/ui/dict/rule/DictRuleScreen.kt
+++ b/app/src/main/java/io/legado/app/ui/dict/rule/DictRuleScreen.kt
@@ -227,6 +227,7 @@ fun DictRuleScreen(
         data = showDeleteRuleDialog,
         onDismissRequest = { showDeleteRuleDialog = null },
         title = stringResource(R.string.delete),
+        text = stringResource(R.string.sure_del),
         confirmText = stringResource(R.string.ok),
         onConfirm = { rule ->
             onIntent(DictRuleIntent.DeleteRule(rule))

--- a/app/src/main/java/io/legado/app/ui/highlightTagRule/HighlightTagRuleScreen.kt
+++ b/app/src/main/java/io/legado/app/ui/highlightTagRule/HighlightTagRuleScreen.kt
@@ -224,6 +224,7 @@ fun HighlightTagRuleScreen(
         data = showDeleteRuleDialog,
         onDismissRequest = { showDeleteRuleDialog = null },
         title = stringResource(R.string.delete),
+        text = stringResource(R.string.sure_del),
         confirmText = stringResource(R.string.ok),
         onConfirm = { rule ->
             onIntent(HighlightTagRuleIntent.DeleteRule(rule))

--- a/app/src/main/java/io/legado/app/ui/replace/ReplaceRuleScreen.kt
+++ b/app/src/main/java/io/legado/app/ui/replace/ReplaceRuleScreen.kt
@@ -280,6 +280,7 @@ fun ReplaceRuleScreen(
         data = showDeleteRuleDialog,
         onDismissRequest = { showDeleteRuleDialog = null },
         title = stringResource(R.string.delete),
+        text = stringResource(R.string.sure_del),
         confirmText = stringResource(R.string.ok),
         onConfirm = { rule ->
             onIntent(ReplaceRuleIntent.DeleteRule(rule))

--- a/app/src/main/java/io/legado/app/ui/rss/source/manage/RssSourceScreen.kt
+++ b/app/src/main/java/io/legado/app/ui/rss/source/manage/RssSourceScreen.kt
@@ -235,6 +235,7 @@ fun RssSourceScreen(
         data = showDeleteRuleDialog,
         onDismissRequest = { showDeleteRuleDialog = null },
         title = stringResource(R.string.delete),
+        text = stringResource(R.string.sure_del),
         confirmText = stringResource(R.string.ok),
         onConfirm = { rule ->
             onIntent(RssSourceIntent.Delete(rule))

--- a/app/src/main/java/io/legado/app/ui/widget/components/GroupManageBottomSheet.kt
+++ b/app/src/main/java/io/legado/app/ui/widget/components/GroupManageBottomSheet.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import io.legado.app.R
+import io.legado.app.ui.widget.components.alert.AppAlertDialog
 import io.legado.app.ui.widget.components.button.series.SmallPlainButton
 import io.legado.app.ui.widget.components.modalBottomSheet.AppModalBottomSheet
 import io.legado.app.ui.widget.components.settingItem.SettingItem
@@ -39,6 +40,21 @@ fun GroupManageBottomSheet(
     onUpdateGroup: (oldGroup: String, newGroup: String) -> Unit,
     onDeleteGroup: (group: String) -> Unit
 ) {
+    var groupToDelete by remember { mutableStateOf<String?>(null) }
+    AppAlertDialog(
+        show = groupToDelete != null,
+        onDismissRequest = { groupToDelete = null },
+        title = stringResource(R.string.delete),
+        text = stringResource(R.string.sure_del),
+        confirmText = stringResource(R.string.ok),
+        onConfirm = {
+            groupToDelete?.let(onDeleteGroup)
+            groupToDelete = null
+            onDismissRequest()
+        },
+        dismissText = stringResource(R.string.cancel),
+        onDismiss = { groupToDelete = null },
+    )
     AppModalBottomSheet(
         show = show,
         onDismissRequest = onDismissRequest,
@@ -49,7 +65,7 @@ fun GroupManageBottomSheet(
                 GroupItem(
                     group = group,
                     onUpdateGroup = onUpdateGroup,
-                    onDeleteGroup = onDeleteGroup
+                    onDeleteGroup = { groupToDelete = it }
                 )
             }
         }

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -431,6 +431,14 @@
     <string name="book_source_check_save_failed">校验失败：无法保存结果，%1$s</string>
     <string name="book_source_check_incomplete">校验失败：任务未完成</string>
     <string name="book_source_check_item_cancelled">校验已取消</string>
+    <string name="book_source_check_default_keyword">我的</string>
+    <string name="book_source_import_success">导入完成</string>
+    <string name="book_source_import_failed">导入失败</string>
+    <string name="book_source_invalid_source">不是书源</string>
+    <string name="book_source_export_open_failed">无法打开导出文件</string>
+    <string name="book_source_export_failed">导出失败：%1$s</string>
+    <string name="book_source_upload_success">上传成功：%1$s</string>
+    <string name="book_source_upload_failed">上传失败：%1$s</string>
     <string name="check_select_source">校验所选</string>
     <string name="progress_show">%1$s      进度 %2$d/%3$d</string>
     <string name="tts_fix">请安装并选择中文 TTS！</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -370,6 +370,14 @@
     <string name="book_source_check_save_failed">校驗失敗：無法保存結果，%1$s</string>
     <string name="book_source_check_incomplete">校驗失敗：任務未完成</string>
     <string name="book_source_check_item_cancelled">校驗已取消</string>
+    <string name="book_source_check_default_keyword">我的</string>
+    <string name="book_source_import_success">導入完成</string>
+    <string name="book_source_import_failed">導入失敗</string>
+    <string name="book_source_invalid_source">不是書源</string>
+    <string name="book_source_export_open_failed">無法打開導出文件</string>
+    <string name="book_source_export_failed">導出失敗：%1$s</string>
+    <string name="book_source_upload_success">上傳成功：%1$s</string>
+    <string name="book_source_upload_failed">上傳失敗：%1$s</string>
     <string name="check_select_source">校驗所選</string>
     <string name="progress_show">%1$s      進度 %2$d/%3$d</string>
     <string name="tts_fix">請安裝並選擇中文 TTS!</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -372,6 +372,14 @@
     <string name="book_source_check_save_failed">校驗失敗：無法儲存結果，%1$s</string>
     <string name="book_source_check_incomplete">校驗失敗：工作未完成</string>
     <string name="book_source_check_item_cancelled">校驗已取消</string>
+    <string name="book_source_check_default_keyword">我的</string>
+    <string name="book_source_import_success">匯入完成</string>
+    <string name="book_source_import_failed">匯入失敗</string>
+    <string name="book_source_invalid_source">不是書源</string>
+    <string name="book_source_export_open_failed">無法開啟匯出檔案</string>
+    <string name="book_source_export_failed">匯出失敗：%1$s</string>
+    <string name="book_source_upload_success">上傳成功：%1$s</string>
+    <string name="book_source_upload_failed">上傳失敗：%1$s</string>
     <string name="check_select_source">校驗所選</string>
     <string name="progress_show">%1$s      進度 %2$d/%3$d</string>
     <string name="tts_fix">請安裝並選擇中文TTS！</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -461,6 +461,14 @@
     <string name="book_source_check_save_failed">Check failed: unable to save result, %1$s</string>
     <string name="book_source_check_incomplete">Check failed: task did not finish</string>
     <string name="book_source_check_item_cancelled">Check cancelled</string>
+    <string name="book_source_check_default_keyword">My</string>
+    <string name="book_source_import_success">Import completed</string>
+    <string name="book_source_import_failed">Import failed</string>
+    <string name="book_source_invalid_source">Not a book source</string>
+    <string name="book_source_export_open_failed">Unable to open export file</string>
+    <string name="book_source_export_failed">Export failed: %1$s</string>
+    <string name="book_source_upload_success">Upload completed: %1$s</string>
+    <string name="book_source_upload_failed">Upload failed: %1$s</string>
     <string name="check_select_source">Check the selected source</string>
     <string name="progress_show">%1$s      Progress %2$d/%3$d</string>
     <string name="tts_fix">Please install and select Chinese TTS!</string>


### PR DESCRIPTION
## 修复内容

- 为书源、RSS 源、词典规则、替换规则和高亮标签规则的删除弹窗补充明确的确认说明。
- 为分组管理弹窗增加删除分组确认；确认删除后关闭分组管理面板。
- 修复书源批量删除确认后未正确分发删除意图的问题。
- 使书源检查选项草稿随 ViewModel 状态更新，避免打开设置后继续使用过期配置。
- 将书源检查默认关键词移入多语言资源，适配当前应用语言。
- 将书源导入、导出、上传流程中的成功、失败及格式错误提示改为资源文案。
- 补充简体中文、繁体中文和英文翻译，避免书源管理流程混用硬编码文本。

## 验证

- 已执行 `git diff --check`，无格式错误。